### PR TITLE
Add ansible.cfg to avoid hostkey checking

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+host_key_checking = False


### PR DESCRIPTION
When deploying during the kube-install.yml SSH host key checking happens
which then results in a hang situation. Using this
ansible.cfg will cause the host key check to be skipped.