### PR TITLE
Fix fact setting and hostvar lookup

### DIFF
--- a/roles/glusterfs-create-volume/tasks/main.yml
+++ b/roles/glusterfs-create-volume/tasks/main.yml
@@ -25,7 +25,7 @@
   register: volume_list
 - name: Create gluster volume name
   set_fact:
-    gluster_volume_name = "glustervol{{ volume_appendix }}"
+    gluster_volume_name : "glustervol{{ volume_appendix }}"
 
 - name: Create glusterFS volume
   shell: >

--- a/roles/glusterfs-probe-peers/tasks/main.yml
+++ b/roles/glusterfs-probe-peers/tasks/main.yml
@@ -9,5 +9,5 @@
 - name: Probe each peer not in the status.
   shell: >
     gluster peer probe {{ hostvars[item]['ansible_host'] }}
-  when: "'hostvars[item]['ansible_host']' not in peer_status.stdout"
+  when: "'{{hostvars[item]['ansible_host']}}' not in peer_status.stdout"
   with_items: "{{ groups['minions'] }}"


### PR DESCRIPTION
The syntax for setting gluster_volume_name was incorrect.  In addition, hostvar lookups in a when clause don't appear to work without mustaches even though you're not supposed to be using them.  Will have to revisit the correct way to do this, but this patch is functional (you get a warning about the when but no errors).