### PR TITLE
[crio] updates for crio, trying to get to work with 1.7 but didn't work

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -5,6 +5,10 @@
 # - crio
 container_runtime: docker
 
+# Which version of crio?
+# (doesn't matter if docker is container runtime)
+crio_version: v1.0.0-beta.0
+
 # Pod net work types
 # A value of "none" will create no networking and will not join minions to cluster.
 # Valid values:

--- a/roles/cri-o-install/tasks/install.yml
+++ b/roles/cri-o-install/tasks/install.yml
@@ -33,8 +33,8 @@
     - pkgconfig
     - json-glib-devel
     - skopeo-containers
-
-
+    - ostree
+    - ostree-devel
 
 - name: Make directories
   file:
@@ -57,7 +57,7 @@
   git:
     repo: https://github.com/kubernetes-incubator/cri-o
     dest: /root/src/github.com/kubernetes-incubator/cri-o
-    version: kube-1.6.x
+    version: "{{ crio_version }}"
 
 - name: clone CNI
   git:
@@ -160,7 +160,7 @@
 - name: systemd dropin for kubeadm
   shell: |
           sh -c 'echo "[Service]
-          Environment=\"KUBELET_EXTRA_ARGS=--enable-cri=true --container-runtime=remote --runtime-request-timeout=15m --image-service-endpoint /var/run/crio.sock --container-runtime-endpoint /var/run/crio.sock\"" > /etc/systemd/system/kubelet.service.d/0-crio.conf'
+          Environment=\"KUBELET_EXTRA_ARGS=--container-runtime=remote --runtime-request-timeout=15m --image-service-endpoint /var/run/crio.sock --container-runtime-endpoint /var/run/crio.sock\"" > /etc/systemd/system/kubelet.service.d/0-crio.conf'
 
 - name: flush iptables
   command: "iptables -F"


### PR DESCRIPTION
But, works if you pin @ 1.6.x e.g. with:

```
$ ansible-playbook -i inventory/vms.inventory -e 'container_runtime=crio' -e 'kube_version=1.6.7-0' kube-install.yml 
```