### PR TITLE
Remove VM disk image on teardown

### DIFF
--- a/roles/vm-teardown/tasks/main.yml
+++ b/roles/vm-teardown/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: Undefine all VMs
   shell: >
-    virsh undefine {{ item }}
+    virsh undefine --remove-all-storage {{ item }}
   with_items: "{{ virtual_machines }}"
   ignore_errors: yes
 


### PR DESCRIPTION
When undefining the virtual machine, we probably want to clean up
the disk image of the OS / virtual machine as well. Adds a command to
remove the disk image of the VM.