### PR TITLE
Pins gluster-kubernetes version to last known good commit

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -64,7 +64,10 @@ multus_ipam_gateway: "192.168.122.1"
 # ----------------------------
 # glusterfs vars
 # ----------------------------
-gluster_kubernetes_version: "v1.2.0"
+# Hey what's that treeish?
+# It's the last known point Doug knows is good.
+# e.g. https://github.com/gluster/gluster-kubernetes/commit/e7799c152bf456dd7692bcb7c86bcef422c7b6c8
+gluster_kubernetes_version: "e7799c152bf456dd7692bcb7c86bcef422c7b6c8"
 spare_disk_size_megs: 10240
 spare_disk_location: "/var/lib/libvirt/images"
 spare_disk_dev: vdb


### PR DESCRIPTION
Oh the woes with gluster-kubernetes today.

To get it to work... 
1. `ansible-playbook -i inventory/vms.inventory -e 'kube_version=1.7.4-0' kube-install.yml` install kube with 1.7.4
2. Change to this commit.