### PR TITLE
[hotfix][minor] Drop hard coded TLD hostname

### DIFF
--- a/roles/vm-spinup/templates/spinup.sh.j2
+++ b/roles/vm-spinup/templates/spinup.sh.j2
@@ -63,7 +63,7 @@ pushd $DIR/$1 > /dev/null
 # Hostname management
 preserve_hostname: False
 hostname: $1
-fqdn: $1.example.local
+fqdn: $1
 
 # Remove cloud-init when finished with it
 runcmd:


### PR DESCRIPTION
The spinup script has a hard coded .example.local TLD that
really isn't necessary (afaict) and actually breaks the setup
when you are using hostnames for the end points.