### PR TITLE
[major] Dynamically generate and control VM inventory

### DIFF
--- a/roles/vm-spinup/defaults/main.yml
+++ b/roles/vm-spinup/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+ssh_proxy_enabled: false
+ssh_proxy_user: root
+ssh_proxy_host: virthost

--- a/roles/vm-spinup/tasks/main.yml
+++ b/roles/vm-spinup/tasks/main.yml
@@ -60,4 +60,10 @@
     dest: /etc/hosts
     line: '{{ item.value }} {{ item.key }}'
     regexp: '{{ item.key }}'
-  with_dict: "{{ vm_ips_dict }}"
+    with_dict: "{{ vm_ips_dict }}"
+
+- name: Build a local inventory
+  template:
+    src: vms.local.j2
+    dest: inventory/vms.local.generated
+  delegate_to: 127.0.0.1

--- a/roles/vm-spinup/templates/vms.local.j2
+++ b/roles/vm-spinup/templates/vms.local.j2
@@ -1,0 +1,28 @@
+{% for key, value in vm_ips_dict.iteritems() %}
+{{ key }} ansible_host={{ value }}
+{% endfor %}
+
+[master]
+kube-master
+
+[minions]
+kube-minion-1
+kube-minion-2
+kube-minion-3
+
+[all_vms]
+kube-master
+kube-minion-1
+kube-minion-2
+kube-minion-3
+
+[all_vms:vars]
+ansible_user=centos
+ansible_become=true
+ansible_become_user=root
+{% if ssh_proxy_enabled %}
+ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p {{ ssh_proxy_user }}@{{ ssh_proxy_host }}"'
+{% endif %}
+{% if vm_ssh_key_path is defined %}
+ansible_ssh_private_key_file={{ vm_ssh_key_path }}
+{% endif %}


### PR DESCRIPTION
This change results in a locally generated inventory of virtual machines
that have been built from the virt-host-setup.yml playbook. You can then
use this dynamic inventory file for the steps beyond the virtual host setup.

Updated the documentation as well showing some of the new variables that
I added, which allows for the usage of a jump host via the SSH Proxy command
and local SSH key, along with variables to define the virthost location.