### PR TITLE
[hotfix] Revert breaking indent

### DIFF
--- a/roles/vm-spinup/tasks/main.yml
+++ b/roles/vm-spinup/tasks/main.yml
@@ -60,7 +60,7 @@
     dest: /etc/hosts
     line: '{{ item.value }} {{ item.key }}'
     regexp: '{{ item.key }}'
-    with_dict: "{{ vm_ips_dict }}"
+  with_dict: "{{ vm_ips_dict }}"
 
 - name: Build a local inventory
   template:


### PR DESCRIPTION
I broke something (vim did it) when I was editing. Too much
indent on the lineinfile module. The with_dict needs to be
backed the hell up. Slow your roll indents.