### PR TITLE
Defaults to running attach disk in virt-host-setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ This document is... Kind of terse. Want a complete walkthrough? Check out my
 | `kube-teardown.yml`   | `./inventory/vms.inventory`      | Runs `kubeadm reset` on all nodes to tear down k8s               |
 | `vm-teardown.yml`     | `./inventory/virthost.inventory` | Destroys VMs on the virtual machine host                         |
 | `multus-cni.yml`      | `./inventory/vms.inventory`      | Compiles [multus-cni](https://github.com/Intel-Corp/multus-cni)  |
-| `vm-attach-disk.yml`  | `./inventory/virthost.inventory` | Attach spare disks to VMs (for GlusterFS, or otherwise)          |
 | `gluster-install.yml` | `inventory/vms.inventory`        | Install a GlusterFS cluster across VMs (requires vm-attach-disk) |
 
 
@@ -60,17 +59,8 @@ host (skip to step 3 if you already have an inventory)
 > * `ssh_proxy_host: virthost`  _hostname or IP of virthost_
 > * `vm_ssh_key_path: /home/lmadsen/.ssh/id_vm_rsa`  _path to local SSH key_
 
-
 ```
 ansible-playbook -i inventory/virthost/virthost.inventory virt-host-setup.yml
-```
-
-
-Step 2b (optional). If you plan to load up some persistent storage using
-GlusterFS you'll want to attach some extra disk images to the virtual machines.
-
-```
-ansible-playbook -i inventory/virthost/virthost.inventory vm-attach-disk.yml
 ```
 
 Step 3. During the execution of _Step 1_ a local inventory should have been

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -68,6 +68,7 @@ multus_ipam_gateway: "192.168.122.1"
 # It's the last known point Doug knows is good.
 # e.g. https://github.com/gluster/gluster-kubernetes/commit/e7799c152bf456dd7692bcb7c86bcef422c7b6c8
 gluster_kubernetes_version: "e7799c152bf456dd7692bcb7c86bcef422c7b6c8"
+gluster_attach_disk: true
 spare_disk_size_megs: 10240
 spare_disk_location: "/var/lib/libvirt/images"
 spare_disk_dev: vdb

--- a/virt-host-setup.yml
+++ b/virt-host-setup.yml
@@ -4,3 +4,4 @@
   roles:
     - { role: virthost-basics }
     - { role: vm-spinup }
+    - { role: attach-disks, when: "gluster_attach_disk == true" }

--- a/vm-attach-disk.yml
+++ b/vm-attach-disk.yml
@@ -1,5 +1,0 @@
----
-- hosts: kubehost
-  tasks: []
-  roles:
-    - { role: attach-disks }


### PR DESCRIPTION
Or you can set `gluster_attach_disk` to false, and omit it.