### PR TITLE
[hotfix] Don't become root when it breaks installation

### DIFF
--- a/roles/vm-spinup/templates/vms.local.j2
+++ b/roles/vm-spinup/templates/vms.local.j2
@@ -18,8 +18,6 @@ kube-minion-3
 
 [all_vms:vars]
 ansible_user=centos
-ansible_become=true
-ansible_become_user=root
 {% if ssh_proxy_enabled %}
 ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p {{ ssh_proxy_user }}@{{ ssh_proxy_host }}"'
 {% endif %}


### PR DESCRIPTION
Remove the global root become from the generated inventory
because it messes with the installation of the GlusterFS
and Heketi components.