### PR TITLE
[feature] adds 'binary install' option to override kubelet (and other) binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,20 @@ version. This version number comes from a `yum search kubelet
 ansible-playbook -i inventory/vms.local.generated kube-install.yml -e 'kube_version=1.6.7-0'
 ```
 
+## Install specific binaries
+
+By default, we install the kubelet (and `kubeadm`, `kubectl` and the core CNI plugins) via RPM. However, if you'd like to install specific binaries for either the kubelet, kubeadm or kubetl -- you can do so by specifying that you'd like to perform a binary install and specify URLs (that point to, say, binaries in a GitHub release).
+
+There are sample variables provided in the `./group_vars/all.yml` file, and you can set them up such as:
+
+```
+binary_install: true
+binary_kubectl_url: https://github.com/leblancd/kubernetes/releases/download/v1.9.0-alpha.1.ipv6.1b/kubectl
+binary_kubeadm_url: https://github.com/leblancd/kubernetes/releases/download/v1.9.0-alpha.1.ipv6.1b/kubeadm
+binary_kubelet_url: https://github.com/leblancd/kubernetes/releases/download/v1.9.0-alpha.1.ipv6.1b/kubelet
+binary_install_force_redownload: false
+```
+
 ## Using CRI-O
 
 You can also enable [CRI-O](http://cri-o.io/) to have an OCI compatible

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -28,6 +28,9 @@ skip_preflight_checks: true
 # Stable. (was busted at 1.6 release, may work now, untested for a couple months)
 kube_baseurl: http://yum.kubernetes.io/repos/kubernetes-el7-x86_64
 
+# Unstable
+# kube_baseurl: http://yum.kubernetes.io/repos/kubernetes-el7-x86_64-unstable
+
 # Kube Version
 # Accepts "latest" or the version part of an RPM (typically based on the kubelet RPM).
 # For example if you were to look at `yum search kubelet --showduplicates`
@@ -37,8 +40,13 @@ kube_baseurl: http://yum.kubernetes.io/repos/kubernetes-el7-x86_64
 # The default is... "latest"
 kube_version: "latest"
 
-# Unstable
-# kube_baseurl: http://yum.kubernetes.io/repos/kubernetes-el7-x86_64-unstable
+# Binary install
+# Essentially replaces the RPM installed binaries with a specific set of binaries from URLs.
+# binary_install: true
+# binary_install_force_redownload: false
+# binary_kubectl_url: https://github.com/leblancd/kubernetes/releases/download/v1.9.0-alpha.1.ipv6.1b/kubectl
+# binary_kubeadm_url: https://github.com/leblancd/kubernetes/releases/download/v1.9.0-alpha.1.ipv6.1b/kubeadm
+# binary_kubelet_url: https://github.com/leblancd/kubernetes/releases/download/v1.9.0-alpha.1.ipv6.1b/kubelet
 
 images_directory: /home/images
 bridge_name: virbr0

--- a/roles/kube-install/defaults/main.yml
+++ b/roles/kube-install/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+binary_install: false
+kubectl_home: /home/centos

--- a/roles/kube-install/tasks/binary_install.yml
+++ b/roles/kube-install/tasks/binary_install.yml
@@ -1,0 +1,50 @@
+---
+
+- name: Check for download complete semaphor
+  stat:
+    path: "{{ kubectl_home }}/.kube-binary-download-complete"
+  register: download_complete_semaphor
+
+- name: Delete existing binaries when necessary
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  with_items:
+    - path: /usr/bin/kubelet
+      url_is_set: "{{ binary_kubelet_url is defined }}"
+    - path: /usr/bin/kubectl
+      url_is_set: "{{ binary_kubectl_url is defined }}"
+    - path: /usr/bin/kubeadm
+      url_is_set: "{{ binary_kubeadm_url is defined }}"
+  when: >
+    item.url_is_set and
+    (download_complete_semaphor.stat.exists == False or binary_install_force_redownload)
+
+- name: Download kubelet
+  get_url:
+    url: "{{ binary_kubelet_url }}"
+    dest: /usr/bin/kubelet
+    mode: 0755
+    force: "{{ binary_install_force_redownload }}"
+  when: binary_kubelet_url is defined
+
+- name: Download kubectl
+  get_url:
+    url: "{{ binary_kubectl_url }}"
+    dest: /usr/bin/kubectl
+    mode: 0755
+    force: "{{ binary_install_force_redownload }}"
+  when: binary_kubectl_url is defined
+
+- name: Download kubeadm
+  get_url:
+    url: "{{ binary_kubeadm_url }}"
+    dest: /usr/bin/kubeadm
+    mode: 0755
+    force: "{{ binary_install_force_redownload }}"
+  when: binary_kubeadm_url is defined
+
+- name: Mark download complete
+  file:
+    path: "{{ kubectl_home }}/.kube-binary-download-complete"
+    state: directory

--- a/roles/kube-install/tasks/main.yml
+++ b/roles/kube-install/tasks/main.yml
@@ -70,7 +70,9 @@
     - kubeadm{{ kube_version_parameter }}
     - kubernetes-cni
 
-
+- name: Optionally include playbook for binary install
+  include: binary_install.yml
+  when: binary_install
 
 - name: Install docker (when using docker mode)
   package:


### PR DESCRIPTION
Allows you to specify URLs for binaries in order to replace the default (RPM installed) binaries for kubelet, kubeadm and kubectl with customized one.

This idea came about initially because Feng mentioned that we'd like to have the ability to do this to use a custom built modification of k/k binaries in order to provision a lab for IPv6.

It may find other uses as well for spinning up a cluster given customized builds of Kubernetes to later run other end-to-end tests of our own scenarios with our own Kubernetes builds, and... Maybe offload the building of Kubernetes from this repo to say, something more focused particularly on that task.

Fixes #81 