### PR TITLE
Drop the use of all_vms

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,14 @@ ansible-playbook -i inventory/vms.local.generated kube-install.yml -e 'kube_vers
 
 ## Install specific binaries
 
-By default, we install the kubelet (and `kubeadm`, `kubectl` and the core CNI plugins) via RPM. However, if you'd like to install specific binaries for either the kubelet, kubeadm or kubetl -- you can do so by specifying that you'd like to perform a binary install and specify URLs (that point to, say, binaries in a GitHub release).
+By default, we install the kubelet (and `kubeadm`, `kubectl` and the core CNI
+plugins) via RPM. However, if you'd like to install specific binaries for
+either the kubelet, kubeadm or kubetl -- you can do so by specifying that you'd
+like to perform a binary install and specify URLs (that point to, say, binaries
+in a GitHub release).
 
-There are sample variables provided in the `./group_vars/all.yml` file, and you can set them up such as:
+There are sample variables provided in the `./group_vars/all.yml` file, and you
+can set them up such as:
 
 ```
 binary_install: true
@@ -115,20 +120,26 @@ binary_install_force_redownload: false
 
 You can also enable [CRI-O](http://cri-o.io/) to have an OCI compatible
 runtime. Set the `container_runtime` variable in
-`inventory/vms.local.generated` under `[all_vms:vars]` or as an extra var when
-you run the playbook:
+`inventory/vms.local.generated` under `[master:vars]` and `[nodes:vars]`, or as
+an extra var when you run the playbook:
 
 ```
 $ ansible-playbook -i inventory/vms.local.generated kube-install.yml -e 'container_runtime=crio'
 ```
 
-Additionally, the compilation of CRI-O requires a beefier machine, memory-wise. It's recommended you spin up the machines with 4 gigs of ram or greater during the VM creation phase, should you use it. One may wish to add the parameters `-e "vm_parameters_ram_mb=4096"` to your playbook run of `virt-host-setup.yml`.
+Additionally, the compilation of CRI-O requires a beefier machine, memory-wise.
+It's recommended you spin up the machines with 4 gigs of ram or greater during
+the VM creation phase, should you use it. One may wish to add the parameters
+`-e "vm_parameters_ram_mb=4096"` to your playbook run of `virt-host-setup.yml`.
 
 ## Using Fedora
 
-Use of Fedora is currently suggested should you require the use of Buildah. Buildah requires functionality in later Linux kernels that are unavailable in recent versions of CentOS.
+Use of Fedora is currently suggested should you require the use of Buildah.
+Buildah requires functionality in later Linux kernels that are unavailable in
+recent versions of CentOS.
 
-Take a gander at the `./inventory/examples/crio/crio.inventory` for an example of how to override the proper variables to use Fedora.
+Take a gander at the `./inventory/examples/crio/crio.inventory` for an example
+of how to override the proper variables to use Fedora.
 
 ## About
 

--- a/fedora-python-bootstrapper.yml
+++ b/fedora-python-bootstrapper.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all_vms
+- hosts: master,nodes
   become: true
   become_user: root
   gather_facts: False

--- a/gluster-install.yml
+++ b/gluster-install.yml
@@ -1,5 +1,5 @@
 ---
-# - hosts: all_vms
+# - hosts: master,nodes
 #   become: true
 #   become_user: root
 #   tasks: []

--- a/gluster-recreate-volumes.yml
+++ b/gluster-recreate-volumes.yml
@@ -14,7 +14,7 @@
         - 4
         - 5
 
-- hosts: all_vms
+- hosts: master,nodes
   become: true
   become_user: root
   tasks:

--- a/gluster-wipe-vg.yml
+++ b/gluster-wipe-vg.yml
@@ -1,4 +1,4 @@
-- hosts: all_vms
+- hosts: master,nodes
   become: true
   become_user: root
   tasks:
@@ -11,6 +11,5 @@
       shell: >
         vgremove {{ vgoutput.stdout }}
       when: "'vg_' in vgoutput.stdout"
-      
-  roles: []
 
+  roles: []

--- a/inventory/examples/crio/crio.inventory
+++ b/inventory/examples/crio/crio.inventory
@@ -17,11 +17,17 @@ kube-master
 [nodes]
 kube-node-1
 
-[all_vms]
-kube-master
-kube-node-1
+[master:vars]
+# Using Fedora
+ansible_ssh_user=fedora
+ansible_ssh_private_key_file=/home/doug/.ssh/id_testvms
+kubectl_home=/home/fedora
+kubectl_user=fedora
+kubectl_group=fedora
+# Using CRI-O (you must set this as an extra var, e.g. `-e "container_runtime=crio"`)
+# container_runtime=crio
 
-[all_vms:vars]
+[nodes:vars]
 # Using Fedora
 ansible_ssh_user=fedora
 ansible_ssh_private_key_file=/home/doug/.ssh/id_testvms

--- a/inventory/examples/vms/vms.inventory
+++ b/inventory/examples/vms/vms.inventory
@@ -11,13 +11,14 @@ kube-node-1
 kube-node-2
 kube-node-3
 
-[all_vms]
-kube-master
-kube-node-1
-kube-node-2
-kube-node-3
+[master:vars]
+ansible_ssh_user=centos
+# ansible_become=true
+# ansible_become_user=root
+# ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p root@192.168.1.119"'
+ansible_ssh_private_key_file=/home/doug/.ssh/id_openshift_hosts
 
-[all_vms:vars]
+[nodes:vars]
 ansible_ssh_user=centos
 # ansible_become=true
 # ansible_become_user=root

--- a/kube-install.yml
+++ b/kube-install.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all_vms
+- hosts: master,nodes
   become: true
   become_user: root
   tasks: []
@@ -12,7 +12,7 @@
     - { role: kube-install }
     - { role: multus-cni, when: pod_network_type == "multus" }
 
-- hosts: all_vms
+- hosts: master,nodes
   become: true
   become_user: root
   tasks:

--- a/kube-teardown.yml
+++ b/kube-teardown.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all_vms
+- hosts: nodes,master
   become: true
   become_user: root
   tasks: []

--- a/multus-cni.yml
+++ b/multus-cni.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all_vms
+- hosts: master,nodes
   tasks: []
   roles:
     - { role: multus-cni }

--- a/roles/glusterfs-kube-config/templates/glusterfs-endpoints.json.j2
+++ b/roles/glusterfs-kube-config/templates/glusterfs-endpoints.json.j2
@@ -5,7 +5,7 @@
     "name": "glusterfs-cluster"
   },
   "subsets": [
-    {% for machine in groups['all_vms'] %}
+{% for machine in groups['master'] + groups['nodes'] %}
     {
       "addresses": [
         {
@@ -18,6 +18,7 @@
         }
       ]
     }{% if not loop.last %},{% endif %}
-    {% endfor %}
+
+{% endfor %}
   ]
 }

--- a/roles/vm-spinup/templates/vms.local.j2
+++ b/roles/vm-spinup/templates/vms.local.j2
@@ -10,13 +10,9 @@ kube-node-1
 kube-node-2
 kube-node-3
 
-[all_vms]
-kube-master
-kube-node-1
-kube-node-2
-kube-node-3
-
-[all_vms:vars]
+{% set kube_groups = ['master','nodes'] %}
+{% for kube_group in kube_groups %}
+[{{ kube_group }}:vars]
 ansible_user=centos
 {% if ssh_proxy_enabled %}
 ansible_ssh_common_args='-o ProxyCommand="ssh{% if ssh_proxy_port is defined %}-p {{ ssh_proxy_port }}{% endif %} -W %h:%p {{ ssh_proxy_user }}@{{ ssh_proxy_host }}"'
@@ -24,3 +20,5 @@ ansible_ssh_common_args='-o ProxyCommand="ssh{% if ssh_proxy_port is defined %}-
 {% if vm_ssh_key_path is defined %}
 ansible_ssh_private_key_file={{ vm_ssh_key_path }}
 {% endif %}
+
+{% endfor %}


### PR DESCRIPTION
When using this role outside of a local (or remote) virtual environment,
the use of all_vms group can cause some issues and confusion (primarily
when you're trying to deploy in something like a cloud environment fronted
by AWX).

This change replaces the use of all_vms with a call to both master and
nodes groups, and updates templates that generate local configuration to
now duplicate the master and nodes vars sections. Documentation has also
been updated to reflect this change.

Closes #80