### PR TITLE
Load virthost privkey onto source machine

### DIFF
--- a/inventory/examples/crio/crio.inventory
+++ b/inventory/examples/crio/crio.inventory
@@ -1,11 +1,11 @@
 kube-master ansible_host=master.example.local
 kube-node-1 ansible_host=node.example.local
-kubehost ansible_host=virt-host.example.local ansible_ssh_user=root
+vmhost ansible_host=virt-host.example.local ansible_ssh_user=root
 
-[kubehost]
-kubehost
+[virthost]
+vmhost
 
-[kubehost:vars]
+[virthost:vars]
 # Using Fedora
 centos_genericcloud_url=https://download.fedoraproject.org/pub/fedora/linux/releases/26/CloudImages/x86_64/images/Fedora-Cloud-Base-26-1.5.x86_64.qcow2
 image_destination_name=Fedora-Cloud-Base-26-1.5.x86_64.qcow2
@@ -20,7 +20,7 @@ kube-node-1
 [master:vars]
 # Using Fedora
 ansible_ssh_user=fedora
-ansible_ssh_private_key_file=/home/doug/.ssh/id_testvms
+ansible_ssh_private_key_file=/home/itsme/.ssh/id_testvms
 kubectl_home=/home/fedora
 kubectl_user=fedora
 kubectl_group=fedora
@@ -30,7 +30,7 @@ kubectl_group=fedora
 [nodes:vars]
 # Using Fedora
 ansible_ssh_user=fedora
-ansible_ssh_private_key_file=/home/doug/.ssh/id_testvms
+ansible_ssh_private_key_file=/home/itsme/.ssh/id_testvms
 kubectl_home=/home/fedora
 kubectl_user=fedora
 kubectl_group=fedora

--- a/inventory/examples/virthost/virthost.inventory
+++ b/inventory/examples/virthost/virthost.inventory
@@ -1,5 +1,5 @@
-kubehost ansible_host=192.168.1.42 ansible_ssh_user=root
+vmhost ansible_host=192.168.1.42 ansible_ssh_user=root
 
-[kubehost]
-kubehost
+[virthost]
+vmhost
 

--- a/roles/virthost-basics/defaults/main.yml
+++ b/roles/virthost-basics/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+centos_genericcloud_url: "http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1611.qcow2"
+image_destination_name: CentOS-7-x86_64-GenericCloud.qcow2

--- a/roles/virthost-basics/tasks/bridge-network.yml
+++ b/roles/virthost-basics/tasks/bridge-network.yml
@@ -1,6 +1,6 @@
 ---
 
-# Some handy links: 
+# Some handy links:
 # [ip command cheat](https://access.redhat.com/sites/default/files/attachments/rh_ip_command_cheatsheet_1214_jcs_print.pdf)
 # [libvirt bridge networking](https://wiki.libvirt.org/page/Networking#Bridged_networking_.28aka_.22shared_physical_device.22.29)
 

--- a/roles/virthost-basics/tasks/main.yml
+++ b/roles/virthost-basics/tasks/main.yml
@@ -47,6 +47,12 @@
     qemu-img resize {{ images_directory }}/{{ image_destination_name }} +{{ increase_root_size_gigs }}G
   when: resize_image and download_image.changed
 
+- name: Generate an ssh key for root
+  user:
+    name: root
+    generate_ssh_key: yes
+    ssh_key_bits: 2048
+    ssh_key_file: .ssh/id_vm_rsa
 
 - name: Generate an ssh key for root
   user:
@@ -54,6 +60,23 @@
     generate_ssh_key: yes
     ssh_key_bits: 2048
     ssh_key_file: .ssh/id_vm_rsa
+
+- name: Setup facts and directory structure for root keys
+  block:
+    - set_fact:
+        vm_ssh_key_path: "{{ lookup('env', 'HOME') }}/.ssh/{{ inventory_hostname }}/id_vm_rsa"
+      when: not vm_ssh_key_path is defined
+
+    - file:
+        state: directory
+        path: "{{ vm_ssh_key_path | dirname }}"
+        mode: 0700
+
+- name: Get root private key
+  fetch:
+    src: .ssh/id_vm_rsa
+    dest: "{{ vm_ssh_key_path }}"
+    flat: yes
 
 - name: Get the public key
   shell: >
@@ -67,7 +90,6 @@
 - name: Your SSH public key
   debug: "msg={{ vm_ssh_key }}"
 
-# Alright, we should fix up the 
 - name: "Include bridge network playbook if necessary"
   include: bridge-network.yml
   when: bridge_networking

--- a/roles/vm-spinup/defaults/main.yml
+++ b/roles/vm-spinup/defaults/main.yml
@@ -2,5 +2,3 @@
 ssh_proxy_enabled: false
 ssh_proxy_user: root
 ssh_proxy_host: virthost
-centos_genericcloud_url: "http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1611.qcow2"
-image_destination_name: CentOS-7-x86_64-GenericCloud.qcow2

--- a/roles/vm-spinup/meta/main.yml
+++ b/roles/vm-spinup/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: virthost-basics }

--- a/virt-host-setup.yml
+++ b/virt-host-setup.yml
@@ -1,6 +1,7 @@
 ---
-- hosts: kubehost
+- hosts: virthost
   tasks: []
+
   roles:
     - { role: virthost-basics }
     - { role: vm-spinup }

--- a/vm-teardown.yml
+++ b/vm-teardown.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: kubehost
+- hosts: virthost
   tasks: []
   roles:
     - { role: vm-teardown }


### PR DESCRIPTION
This change adds the functionality to pull the remotely created SSH
private key from the virtual host onto the source host. It does this
via the fetch module which retrieves the generated root SSH private
key so that authentication can be done when running the
kube-install.yml playbook.

We place the key into the source machines
$HOME/.ssh/{{ inventory_host }}/ directory so that we don't conflict
with other local files.

Additionally, in order to make things cleaner and more obvious, I have
renamed the kubehost group to virthost and performed some other minor
cleanup. Because I'm a bit of a badass like that.

Closes #61