### PR TITLE
Add node_type assigment to nodes

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -50,10 +50,14 @@ kube_version: "latest"
 
 images_directory: /home/images
 virtual_machines:
-  - kube-master
-  - kube-node-1
-  - kube-node-2
-  - kube-node-3
+  - name: kube-master
+    node_type: master
+  - name: kube-node-1
+    node_type: nodes
+  - name: kube-node-2
+    node_type: nodes
+  - name: kube-node-3
+    node_type: nodes
 vm_parameters_ram_mb: 2048
 vm_parameters_cpus: 4
 

--- a/roles/attach-disks/tasks/main.yml
+++ b/roles/attach-disks/tasks/main.yml
@@ -5,24 +5,15 @@
 
 - name: Create images for spare disks
   shell: >
-    qemu-img create -f raw {{ spare_disk_location }}/{{ item }}.img {{ spare_disk_size_megs }}M
+    qemu-img create -f raw {{ spare_disk_location }}/{{ item.name }}.img {{ spare_disk_size_megs }}M
   args:
-    creates: "{{ spare_disk_location }}/{{ item }}.img"
+    creates: "{{ spare_disk_location }}/{{ item.name }}.img"
   with_items: "{{ virtual_machines }}"
-
-# --- I'll leave this for posterity, but, I went for a simpler approach that didn't need xml
-# - name: Template disk xml
-#   template:
-#     src: storage.xml.j2
-#     dest: "/tmp/storage-{{ item }}.xml"
-#   vars:
-#     source_path: "{{ spare_disk_location }}/{{ item }}.img"
-#   with_items: "{{ virtual_machines }}"
 
 - name: Attach disk
   shell: >
-    virsh attach-disk "{{ item }}" {{ spare_disk_location }}/{{ item }}.img vdb --cache none &&
-    touch {{ spare_disk_location }}/.attached-{{ item }}
+    virsh attach-disk "{{ item.name }}" {{ spare_disk_location }}/{{ item.name }}.img vdb --cache none &&
+    touch {{ spare_disk_location }}/.attached-{{ item.name }}
   args:
-    creates: "{{ spare_disk_location }}/.attached-{{ item }}"
+    creates: "{{ spare_disk_location }}/.attached-{{ item.name }}"
   with_items: "{{ virtual_machines }}"

--- a/roles/vm-spinup/tasks/main.yml
+++ b/roles/vm-spinup/tasks/main.yml
@@ -22,27 +22,20 @@
 
 - name: Run spinup for each host that doesn't exist
   shell: >
-    /root/spinup.sh {{ item }}
-  when: "item not in virsh_list.stdout"
+    /root/spinup.sh {{ item.name }}
+  when: "item.name not in virsh_list.stdout"
   with_items: "{{ virtual_machines }}"
-
-# - name: Get IP Addresses for all VMs
-#   shell: >
-#     grep -B1 $(virsh dumpxml {{ item }} | awk -F\' '/mac address/ {print $2}') /var/lib/libvirt/dnsmasq/{{ bridge_name }}.status | head -n 1 | awk '{print $2}' | sed -e s/\"//g -e s/,//
-#   register: vm_ip_addresses
-#   with_items: "{{ virtual_machines }}"
-#   when: not bridge_networking
 
 - name: Get IP Addresses for all VMs
   shell: >
-    cat /tmp/{{ item }}.ip.txt
+    cat /tmp/{{ item.name }}.ip.txt
   register: vm_ip_addresses
   with_items: "{{ virtual_machines }}"
   # when: bridge_networking
 
 - name: Populate dictionary of IPs
   set_fact:
-    vm_ips_dict: "{{ vm_ips_dict|default({}) | combine( {item.item: item.stdout} ) }}"
+    vm_ips_dict: "{{ vm_ips_dict|default({}) | combine( {item.item.name: item.stdout} ) }}"
   with_items: "{{ vm_ip_addresses.results }}"
 
 - name: Here are the IPs of the VMs

--- a/roles/vm-spinup/templates/vms.local.j2
+++ b/roles/vm-spinup/templates/vms.local.j2
@@ -2,17 +2,14 @@
 {{ key }} ansible_host={{ value }}
 {% endfor %}
 
-[master]
-kube-master
+{% for grouper, list in virtual_machines|groupby('node_type') %}
+[{{ grouper }}]
+{% for server in list %}
+{{ server.name }}
+{% endfor %}
+{% endfor %}
 
-[nodes]
-kube-node-1
-kube-node-2
-kube-node-3
-
-{% set kube_groups = ['master','nodes'] %}
-{% for kube_group in kube_groups %}
-[{{ kube_group }}:vars]
+[all:vars]
 ansible_user=centos
 {% if ssh_proxy_enabled %}
 ansible_ssh_common_args='-o ProxyCommand="ssh{% if ssh_proxy_port is defined %}-p {{ ssh_proxy_port }}{% endif %} -W %h:%p {{ ssh_proxy_user }}@{{ ssh_proxy_host }}"'
@@ -20,5 +17,3 @@ ansible_ssh_common_args='-o ProxyCommand="ssh{% if ssh_proxy_port is defined %}-
 {% if vm_ssh_key_path is defined %}
 ansible_ssh_private_key_file={{ vm_ssh_key_path }}
 {% endif %}
-
-{% endfor %}


### PR DESCRIPTION
Pulls in the changes that are currently present in the IPv6
lab branch. This change allows you to add other node types
to the deployment that aren't necessarily directly related to
the Kubernetes virtual nodes being created.

Closes #102