### PR TITLE
Allow customization of VM vCPU and vRAM values

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,11 @@ Modify `./inventory/virthost/virthost.inventory` to setup a virtual
 host (skip to step 3 if you already have an inventory).
 
 Want more VMs? Edit `inventory/virthost/group_vars/virthost.yml` and add
-an override list via `virtual_machines` (template in `group_vars/all.yml`).
+an override list via `virtual_machines` (template in `group_vars/all.yml`). You
+can also define separate vCPU and vRAM for each of the virtual machines with
+`system_ram_mb` and `system_cpus`. The default values are setup via
+`system_default_ram_mb` and `system_default_cpus` which can also be overridden
+if you wish different default values. (Current defaults are 2048MB and 4 vCPU.)
 
 > **WARNING**
 >

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -49,6 +49,8 @@ kube_version: "latest"
 # binary_kubelet_url: https://github.com/leblancd/kubernetes/releases/download/v1.9.0-alpha.1.ipv6.1b/kubelet
 
 images_directory: /home/images
+system_default_ram_mb: 2048
+system_default_cpus: 4
 virtual_machines:
   - name: kube-master
     node_type: master
@@ -60,8 +62,8 @@ virtual_machines:
     node_type: nodes
 # - name: my-support-node
 #   node_type: other
-vm_parameters_ram_mb: 2048
-vm_parameters_cpus: 4
+#   system_ram_mb: 8192
+#   system_cpus: 8
 
 # Implement a work-around for this:
 # https://github.com/kubernetes/kubernetes/issues/43815

--- a/roles/vm-spinup/defaults/main.yml
+++ b/roles/vm-spinup/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 ssh_proxy_enabled: false
 ssh_proxy_user: root
+system_default_ram_mb: 2048
+system_default_cpus: 4

--- a/roles/vm-spinup/tasks/main.yml
+++ b/roles/vm-spinup/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Template the SSH spinup script
   template:
     src: spinup.sh.j2
@@ -22,7 +21,7 @@
 
 - name: Run spinup for each host that doesn't exist
   shell: >
-    /root/spinup.sh {{ item.name }}
+    /root/spinup.sh {{ item.name }} {{ item.system_ram_mb | default(system_default_ram_mb) }} {{ item.system_cpus | default(system_default_cpus) }}
   when: "item.name not in virsh_list.stdout"
   with_items: "{{ virtual_machines }}"
 

--- a/roles/vm-spinup/templates/spinup.sh.j2
+++ b/roles/vm-spinup/templates/spinup.sh.j2
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Take one argument from the commandline: VM name
-if ! [ $# -eq 1 ]; then
-    echo "Usage: $0 <node-name>"
+if [ $# -gt 3 ] || [ $# -lt 1 ]; then
+    echo "Usage: $0 <node-name> {memory-MB} {vCPUs}"
     exit 1
 fi
 
@@ -26,10 +26,10 @@ DIR={{ images_directory }}
 IMAGE={{ images_directory }}/{{ image_destination_name }}
 
 # Amount of RAM in MB
-MEM={{ vm_parameters_ram_mb }}
+MEM=${2:-{{ system_default_ram_mb }}}
 
 # Number of virtual CPUs
-CPUS={{ vm_parameters_cpus }}
+CPUS=${3:-{{ system_default_cpus }}}
 
 # Cloud init files
 USER_DATA=user-data


### PR DESCRIPTION
Allow specification of vCPU and vRAM for the virtual machines via the
system_ram_mb and system_cpus parameters. Sets default values that match
the historical defaults, and update the spinup.sh to account for these
new possible arguments.

Closes #99