### PR TITLE
Drop when clause in var include for kube-install

### DIFF
--- a/roles/kube-install/tasks/variables.yml
+++ b/roles/kube-install/tasks/variables.yml
@@ -1,4 +1,3 @@
 ---
 - name: Include variables for Red Hat systems
   include_vars: "{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
-  when: ansible_distribution_major_version < 20


### PR DESCRIPTION
For some reason, the ansible_major_distribution_major_version is causing issues when
trying to include some variables. We're only supporting major versions 6 (slightly)
and 7 anyways, so dropping this for now since it's not really useful.