### PR TITLE
Fix proxy ssh failure in vms.local.generated

### DIFF
--- a/roles/vm-spinup/templates/vms.local.j2
+++ b/roles/vm-spinup/templates/vms.local.j2
@@ -19,7 +19,7 @@
 [all:vars]
 ansible_user=centos
 {% if ssh_proxy_enabled %}
-ansible_ssh_common_args='-o ProxyCommand="ssh{% if ssh_proxy_port is defined %}-p {{ ssh_proxy_port }}{% endif %} -W %h:%p {{ ssh_proxy_user }}@{{ ssh_proxy_host }}"'
+ansible_ssh_common_args='-o ProxyCommand="ssh{% if ssh_proxy_port is defined %} -p {{ ssh_proxy_port }}{% endif %} -W %h:%p {{ ssh_proxy_user }}@{{ ssh_proxy_host }}"'
 {% endif %}
 {% if vm_ssh_key_path is defined %}
 ansible_ssh_private_key_file={{ vm_ssh_key_path }}


### PR DESCRIPTION
When using a vms.local.generated inventory file with proxy setup, then it'll
fail due to a missing space prior to the -p for the ssh port.