### PR TITLE
Adds ability to build k8s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ group_vars/
 # ignore externally installed roles
 roles/install-go
 roles/install-docker
+roles/auto-kube-dev

--- a/builder-setup.yml
+++ b/builder-setup.yml
@@ -1,0 +1,12 @@
+# vim: set tabstop=2 shiftwidth=2 expandtab:
+---
+- hosts: builder
+  tasks: []
+  roles:
+    - { role: auto-kube-dev/roles/verify-environment, when: "perform_hardware_checks" }
+    - { role: auto-kube-dev/roles/install-deps-utils, become: true, become_user: "root" }
+    - { role: install-go }
+    - { role: install-docker, become: true, become_user: "root" }
+    - { role: auto-kube-dev/roles/install-bazel, when: "use_bazel_rpm" }
+    - { role: auto-kube-dev/roles/install-planter, when: "use_planter" }
+    - { role: auto-kube-dev/roles/setup-repos }

--- a/builder-setup.yml
+++ b/builder-setup.yml
@@ -1,12 +1,31 @@
 # vim: set tabstop=2 shiftwidth=2 expandtab:
 ---
-- hosts: builder
-  tasks: []
-  roles:
-    - { role: auto-kube-dev/roles/verify-environment, when: "perform_hardware_checks" }
-    - { role: auto-kube-dev/roles/install-deps-utils, become: true, become_user: "root" }
-    - { role: install-go }
-    - { role: install-docker, become: true, become_user: "root" }
-    - { role: auto-kube-dev/roles/install-bazel, when: "use_bazel_rpm" }
-    - { role: auto-kube-dev/roles/install-planter, when: "use_planter" }
-    - { role: auto-kube-dev/roles/setup-repos }
+  - import_role:
+      name: auto-kube-dev/roles/verify-environment
+    when: perform_hardware_checks
+
+  - import_role:
+      name: auto-kube-dev/roles/install-deps-utils
+    vars:
+      become: true
+      become_user: "root"
+
+  - import_role:
+      name: install-go
+
+  - import_role:
+      name: install-docker
+    vars:
+      become: true
+      become_user: "root"
+
+  - import_role:
+      name: auto-kube-dev/roles/setup-repos
+
+  - import_role:
+      name: auto-kube-dev/roles/install-bazel
+    when: "use_bazel_rpm"
+
+  - import_role:
+      name: auto-kube-dev/roles/install-planter
+    when: "use_planter"

--- a/builder.yml
+++ b/builder.yml
@@ -3,11 +3,7 @@
 
 - hosts: builder
   tasks:
-    # TODO: the auto-kube-dev has a hosts: line. Break it out in the repo so
-    # I can consume the roles list directly, without the hosts. Create a new site.yml
-    # that will have the hosts line required for auto-kube-dev. Now you can avoid
-    # duplication.
-    - include: roles/auto-kube-dev/auto-kube-dev.yaml
+    - import_tasks: builder-setup.yml
       when: builder_setup
 
     - name: Run build

--- a/builder.yml
+++ b/builder.yml
@@ -1,0 +1,16 @@
+# vim: set tabstop=2 shiftwidth=2 expandtab:
+---
+
+- hosts: builder
+  tasks:
+    # TODO: the auto-kube-dev has a hosts: line. Break it out in the repo so
+    # I can consume the roles list directly, without the hosts. Create a new site.yml
+    # that will have the hosts line required for auto-kube-dev. Now you can avoid
+    # duplication.
+    - include: roles/auto-kube-dev/auto-kube-dev.yaml
+      when: builder_setup
+
+    - name: Run build
+      command: ./../planter/planter.sh make bazel-release
+      args:
+        chdir: "{{ ansible_env.HOME }}/src/go/src/k8s.io/kubernetes"

--- a/docs/building_k8s.md
+++ b/docs/building_k8s.md
@@ -1,0 +1,81 @@
+# Building Kubernetes Releases
+
+You can instantiate a virtual machine with kube-centos-ansible in order to
+build a Kubernetes release from the upstream Kubernetes git repository. To do
+this, you create a heavy (on resources) virtual machine, install the
+dependencies, and then run `make bazel-release` using
+[Planter](https://github.com/kubernetes/test-infra/tree/master/planter).
+
+## Instantiating a Virtual Machine
+
+Assuming you're familiar with kube-centos-ansible, getting the virtual machine
+up and running for a build is relatively straight forward. You add a new
+builder VM to your `group_vars/all.yml` file under the `virtual_machines` list.
+
+An example `virtual_machines` list:
+
+```
+virtual_machines:
+  - name: kube-master
+    node_type: master
+  - name: kube-node-1
+    node_type: nodes
+  - name: kube-node-2
+    node_type: nodes
+  - name: kube-node-3
+    node_type: nodes
+  - name: builder
+    node_type: builder
+    system_ram_mb: 24576
+
+```
+
+With our new `builder` machine added to the list, we also need to define some
+additional values for the build machine, since it requires quite a few
+resources. We have provided the recommended values in the
+`group_vars/builder.yml`, so unless you have a need to tune these values,
+you're done :) (These values will only be applied to the builder virtual
+machine.)
+
+With our configuration done, let's spin up the environment with
+`virthost-setup.yml`.
+
+```
+ansible-playbook -i inventory/virthost/ virthost-setup.yml
+```
+
+When your deployment is done, you'll have the virtual machines for both your
+Kubernetes environment, and your build environment.
+
+## Building a Kubernetes Release
+
+To build a Kubernetes release with [Bazel](https://bazel.build/), then we need
+to execute the `builder.yml` playbook. We consume roles from
+[auto-kube-dev](https://github.com/redhat-nfvpe/auto-kube-dev) to build a
+Kubernetes release.
+
+(You can also independently create a build environment with
+[auto-kube-dev](https://github.com/redhat-nfvpe/auto-kube-dev). We're simply
+consuming the same functionality, and then wrapping it with some additional
+automation to make the building even easier.)
+
+Before we run `builder.yml`, we need to install role dependencies. We can do
+this with `ansible-galaxy` and feeding in the `requirements.yml` file.
+
+```
+ansible-galaxy install -r requirements.yml
+```
+
+With our dependencies installed, we can now build a Kubernetes release with
+Bazel.
+
+```
+ansible-playbook -i inventory/vms.local.generated builder.yml
+```
+
+During the run, dependencies will be installed on the `builder` virtual
+machine, Kubernetes repositories will be cloned, Docker setup, and Planter
+executed to build the release.
+
+The resulting release binaries will be on the builder virtual machine in
+`/home/centos/src/go/src/k8s.io/kubernetes/bazel-bin/build/release-tars/`.

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -60,13 +60,13 @@ virtual_machines:
     node_type: nodes
   - name: kube-node-3
     node_type: nodes
-  - name: builder
-    node_type: builder
-    system_ram_mb: 24576
-# - name: my-support-node
-#   node_type: other
-#   system_ram_mb: 8192
-#   system_cpus: 8
+#  - name: builder
+#    node_type: builder
+#    system_ram_mb: 24576
+#  - name: my-support-node
+#    node_type: other
+#    system_ram_mb: 8192
+#    system_cpus: 8
 
 # Implement a work-around for this:
 # https://github.com/kubernetes/kubernetes/issues/43815

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -60,6 +60,9 @@ virtual_machines:
     node_type: nodes
   - name: kube-node-3
     node_type: nodes
+  - name: builder
+    node_type: builder
+    system_ram_mb: 24576
 # - name: my-support-node
 #   node_type: other
 #   system_ram_mb: 8192

--- a/inventory/examples/crio/crio.inventory
+++ b/inventory/examples/crio/crio.inventory
@@ -9,7 +9,7 @@ vmhost
 # Using Fedora
 centos_genericcloud_url=https://download.fedoraproject.org/pub/fedora/linux/releases/26/CloudImages/x86_64/images/Fedora-Cloud-Base-26-1.5.x86_64.qcow2
 image_destination_name=Fedora-Cloud-Base-26-1.5.x86_64.qcow2
-increase_root_size_gigs=10
+set_root_disk_gb=18
 
 [master]
 kube-master

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,3 +5,6 @@
 - src: https://github.com/redhat-nfvpe/ansible-role-install-docker
   name: install-docker
   version: master
+- src: https://github.com/redhat-nfvpe/auto-kube-dev
+  name: auto-kube-dev
+  version: master

--- a/roles/virthost-basics/tasks/main.yml
+++ b/roles/virthost-basics/tasks/main.yml
@@ -42,12 +42,12 @@
 - name: Flag for resizing
   set_fact:
     resize_image: true
-  when: increase_root_size_gigs is defined
+  when: set_root_disk_gb is defined
 
 - name: Increase root disk size (optionally)
   shell: >
-    qemu-img resize {{ images_directory }}/{{ image_destination_name }} +{{ increase_root_size_gigs }}G
-  when: resize_image and download_image.changed
+    qemu-img resize {{ images_directory }}/{{ image_destination_name }} {{ set_root_disk_gb }}G
+  when: resize_image
 
 - name: Generate an ssh key for root
   user:
@@ -65,11 +65,13 @@
 
 - name: Setup facts and directory structure for root keys
   block:
-    - set_fact:
+    - name: Set vm_ssh_key_path optionally
+      set_fact:
         vm_ssh_key_path: "{{ lookup('env', 'HOME') }}/.ssh/{{ inventory_hostname }}/id_vm_rsa"
       when: not vm_ssh_key_path is defined
 
-    - file:
+    - name: Set proper mode on vm_ssh_key_path directory
+      file:
         state: directory
         path: "{{ vm_ssh_key_path | dirname }}"
         mode: 0700

--- a/roles/vm-spinup/templates/vms.local.j2
+++ b/roles/vm-spinup/templates/vms.local.j2
@@ -19,7 +19,7 @@
 [all:vars]
 ansible_user=centos
 {% if ssh_proxy_enabled %}
-ansible_ssh_common_args='-o ProxyCommand="ssh{% if ssh_proxy_port is defined %}-p {{ ssh_proxy_port }}{% endif %} -W %h:%p {{ ssh_proxy_user }}@{{ ssh_proxy_host }}"'
+ansible_ssh_common_args='-o ProxyCommand="ssh{% if ssh_proxy_port is defined %} -p {{ ssh_proxy_port }}{% endif %} -W %h:%p {{ ssh_proxy_user }}@{{ ssh_proxy_host }}"'
 {% endif %}
 {% if vm_ssh_key_path is defined %}
 ansible_ssh_private_key_file={{ vm_ssh_key_path }}


### PR DESCRIPTION
Adds the builder.yml which provides an automated means to build a
kubernetes release from the upstream kubernetes git repository. Uses
planter to execute a make bazel-release, resulting in a release build
within a builder virtual machine.

Documentation also added to show how to utilize the new build system.

Closes #118