### PR TITLE
[hotfix] Multus CRD typo in template name

### DIFF
--- a/roles/kube-template-cni/tasks/main.yml
+++ b/roles/kube-template-cni/tasks/main.yml
@@ -8,7 +8,7 @@
 
 - name: Template CRD flavored multus.yaml
   template:
-    src: multus.yaml.j2
+    src: multus-crd.yaml.j2
     dest: /etc/multus-crd.yaml
   when: multus_use_crd
 

--- a/roles/kube-template-cni/templates/multus-crd.yaml.j2
+++ b/roles/kube-template-cni/templates/multus-crd.yaml.j2
@@ -16,7 +16,7 @@ metadata:
 data:
   cni-conf.json: |
     {
-      "name": "minion-cni-network",
+      "name": "multus-cni-network",
       "type": "multus",
       "kubeconfig": "/etc/kubernetes/kubelet.conf"
     }


### PR DESCRIPTION
and more appropriate CNI config `name:` param