### PR TITLE
Copies artifacts from the builder to the k8s nodes

### DIFF
--- a/builder.yml
+++ b/builder.yml
@@ -3,10 +3,27 @@
 
 - hosts: builder
   tasks:
-    - import_tasks: builder-setup.yml
-      when: builder_setup
+    # this will setup the build node in preparation for compiling
+    - import_tasks: tasks/builder/setup.yml
+      when: skip_builder_setup is defined and not skip_builder_setup
 
-    - name: Run build
-      command: ./../planter/planter.sh make bazel-release
+- hosts: builder
+  tasks:
+    - name: Build Kubernetes (this will take a while)
+      shell: ./../planter/planter.sh make bazel-build
       args:
         chdir: "{{ ansible_env.HOME }}/src/go/src/k8s.io/kubernetes"
+      when: skip_build is defined and not skip_build
+
+    # this will synchronize the artifacts over to the k8s nodes
+    - include_tasks: tasks/builder/sync.yml
+      with_inventory_hostnames:
+        - master
+        - nodes
+      loop_control:
+        loop_var: k8s_hostname
+
+# move files around on the remote nodes
+- hosts: master,nodes
+  tasks:
+    - include_tasks: tasks/builder/move.yml

--- a/docs/building_k8s.md
+++ b/docs/building_k8s.md
@@ -78,4 +78,15 @@ machine, Kubernetes repositories will be cloned, Docker setup, and Planter
 executed to build the release.
 
 The resulting release binaries will be on the builder virtual machine in
-`/home/centos/src/go/src/k8s.io/kubernetes/bazel-bin/build/release-tars/`.
+`/home/centos/src/go/src/k8s.io/kubernetes/bazel-bin/build/`.
+
+## Copying Artifacts to Kubernetes Nodes
+
+When you run the `builder.yml`, at the end of the build, the artifacts will be
+copied over to your Kubernetes nodes (assuming you're consuming the
+automatically built inventory file `vms.local.generated`, otherwise you need to
+specify your own inventory file that contains the `master` and `nodes` groups
+of your Kubernetes nodes).
+
+Artifacts are copied onto the Kubernetes nodes and placed in the
+`/opt/k8s/artifacts/` directory.

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -116,3 +116,15 @@ bridge_network_name: "br0"
 bridge_network_cidr: 192.168.1.0/24
 
 ipv6_enabled: false
+
+# builder archive list
+archive_list:
+  - rpms/kubeadm-x86_64.rpm
+  - rpms/kubectl-x86_64.rpm
+  - rpms/kubelet-x86_64.rpm
+  - rpms/kubernetes-cni-x86_64.rpm
+  - cloud-controller-manager.tar
+  - kube-apiserver.tar
+  - kube-controller-manager.tar
+  - kube-proxy.tar
+  - kube-scheduler.tar

--- a/tasks/builder/move.yml
+++ b/tasks/builder/move.yml
@@ -1,0 +1,46 @@
+---
+- name: Create temporary artifacts directory
+  file:
+    state: directory
+    path: /tmp/k8s_artifacts/
+    mode: 0755
+
+- name: Create artifacts directory on k8s nodes
+  become: true
+  become_user: root
+  file:
+    state: directory
+    path: /opt/k8s/artifacts
+    mode: 0755
+
+- name: Get list of files in tmp archive
+  find:
+    path: /tmp/k8s_artifacts/
+  register: k8s_artifacts
+
+- name: Copy files from tmp into opt as root
+  become: true
+  become_user: root
+  copy:
+    src: "{{ item.path }}"
+    dest: /opt/k8s/artifacts/
+    owner: root
+    group: root
+    remote_src: yes
+  with_items: "{{ k8s_artifacts.files }}"
+
+- name: Remove the temporary archive directory
+  file:
+    state: absent
+    path: /tmp/k8s_artifacts
+
+- name: Set proper permissions on k8s artifacts directory
+  become: true
+  become_user: root
+  file:
+    state: directory
+    path: /opt/k8s/artifacts
+    recurse: yes
+    owner: root
+    group: root
+  delegate_to: "{{ inventory_hostname }}"

--- a/tasks/builder/setup.yml
+++ b/tasks/builder/setup.yml
@@ -6,18 +6,16 @@
 
   - import_role:
       name: auto-kube-dev/roles/install-deps-utils
-    vars:
-      become: true
-      become_user: "root"
+    become: true
+    become_user: "root"
 
   - import_role:
       name: install-go
 
   - import_role:
       name: install-docker
-    vars:
-      become: true
-      become_user: "root"
+    become: true
+    become_user: "root"
 
   - import_role:
       name: auto-kube-dev/roles/setup-repos

--- a/tasks/builder/sync.yml
+++ b/tasks/builder/sync.yml
@@ -1,0 +1,9 @@
+---
+- name: Synchronize artifacts to kubernetes cluster
+  synchronize:
+    src: "{{ ansible_env.HOME }}/src/go/src/k8s.io/kubernetes/bazel-bin/build/{{ item }}"
+    dest: "/tmp/k8s_artifacts/"
+    mode: pull
+  delegate_to: "{{ k8s_hostname }}"
+  with_items: "{{ archive_list }}"
+


### PR DESCRIPTION
This change moves the artifacts built from a k8s build over to the k8s
nodes (master and nodes groups).

In order to allow the synchronize module (rsync) to work properly with
the SSH keys, we need to execute this as a non-root user to copy the
files over. When we do this, the files are placed into a temporary
k8s_artifacts directory.

Once the sync is completed, then a separate set of tasks is run to
copy the files on the remote node into their final destination, set
the proper owner, and then delete the temporary k8s_artifacts
directory from the /tmp/ directory.

Closes #119