### PR TITLE
[hotfix] Revert erroneous lint fix in attach disks

### DIFF
--- a/roles/attach-disks/tasks/main.yml
+++ b/roles/attach-disks/tasks/main.yml
@@ -11,7 +11,7 @@
   with_items: "{{ virtual_machines }}"
 
 - name: Attach disk
-  command: >
+  shell: >
     virsh attach-disk "{{ item.name }}" {{ spare_disk_location }}/{{ item.name }}.img vdb --cache none &&
     touch {{ spare_disk_location }}/.attached-{{ item.name }}
   args:


### PR DESCRIPTION
Need to use shell instead of command in attach disks role because of the
use of a double ampersand.