### PR TITLE
[feature][minor] adds variable to skip virthost depedencies

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -107,6 +107,11 @@ brick_size: "1980"
 # ----------------------------
 # virt-host vars.
 # ----------------------------
+
+# Allows one to skip the steps to initially setup a virthost
+# convenient when iterating quickly.
+skip_virthost_depedencies: false
+
 # Enables a bridge to the outside LAN
 # (as opposed to using virbr0)
 bridge_networking: false

--- a/virthost-setup.yml
+++ b/virthost-setup.yml
@@ -3,6 +3,6 @@
   tasks: []
 
   roles:
-    - { role: virthost-basics }
+    - { role: virthost-basics, when: "not skip_virthost_depedencies" }
     - { role: vm-spinup }
     - { role: attach-disks, when: "gluster_attach_disk == true" }


### PR DESCRIPTION
Just a var defaulted to true, and `when:` in the virthost initial setup role

Fixes #133 