### PR TITLE
Avoids duplicating builder plays

### DIFF
--- a/tasks/builder/setup.yml
+++ b/tasks/builder/setup.yml
@@ -10,15 +10,9 @@
     become_user: "root"
 
   - import_role:
-      name: install-go
-
-  - import_role:
       name: install-docker
     become: true
     become_user: "root"
-
-  - import_role:
-      name: auto-kube-dev/roles/setup-repos
 
   - import_role:
       name: auto-kube-dev/roles/install-bazel

--- a/tasks/builder/sync.yml
+++ b/tasks/builder/sync.yml
@@ -6,4 +6,3 @@
     mode: pull
   delegate_to: "{{ k8s_hostname }}"
   with_items: "{{ archive_list }}"
-


### PR DESCRIPTION
With the dependencies setup correctly on auto-kube-dev, we can remove the duplicate
calls to a couple of roles in the builder/tasks/setup playbook.

Closes #145