### PR TITLE
Use Docker CE repo for builder VM

### DIFF
--- a/tasks/builder/setup.yml
+++ b/tasks/builder/setup.yml
@@ -16,6 +16,8 @@
       name: install-docker
     become: true
     become_user: "root"
+    vars:
+      docker_repo_type: "ce"
 
   - import_role:
       name: auto-kube-dev/roles/setup-repos


### PR DESCRIPTION
Planter release 0.8.1 now uses the --mount option from Docker, which is only
available in Docker 17.06 or later. CentOS Docker packages are setup for Docker
version 1.12 as the latest, thus building with Planter is no longer possible
with the CentOS Docker packages.

This change leverages the latest changes in ansible-role-install-docker which
allows for installation of Docker from the OS (CentOS) or from Docker CE
repositories.

The change only affects Docker installation on the Builder machine, so we
shouldn't run into any problems on the Kubernetes VM nodes.

Closes #147