### PR TITLE
[enhance] Provide method to only sync artifacts

### DIFF
--- a/builder.yml
+++ b/builder.yml
@@ -22,8 +22,12 @@
         - nodes
       loop_control:
         loop_var: k8s_hostname
+      tags:
+        - sync_artifacts
 
 # move files around on the remote nodes
 - hosts: master,nodes
   tasks:
     - include_tasks: tasks/builder/move.yml
+      tags:
+        - sync_artifacts

--- a/docs/building_k8s.md
+++ b/docs/building_k8s.md
@@ -90,3 +90,13 @@ of your Kubernetes nodes).
 
 Artifacts are copied onto the Kubernetes nodes and placed in the
 `/opt/k8s/artifacts/` directory.
+
+> **TIP**
+>
+> If you need to resync artifacts over to the virtual machines (for example, if
+> you tore down your Kubernetes cluster, reinstantiated, but didn't destroy the
+> builder VM with the artifacts) you can avoid rebuilding the entire set of
+> artifacts and synchronize them back over using the `sync_artifacts` Ansible
+> tag.
+>
+> `ansible-playbook -i inventory/vms.local.generated --tags sync_artifacts builder.yml`

--- a/tasks/builder/sync.yml
+++ b/tasks/builder/sync.yml
@@ -6,3 +6,5 @@
     mode: pull
   delegate_to: "{{ k8s_hostname }}"
   with_items: "{{ archive_list }}"
+  tags:
+    - sync_artifacts


### PR DESCRIPTION
Sometimes you might find it necessary to re-sync the artifacts over from
the builder machine to the Kubernetes VMs (in my case, I had to fix some
SSH key stuff). It would be nice to re-sync the files over without having
to rebuild everything from scratch.

This change provides a new Ansible tag that you can use that will only run
the artifact sync, and skip all the build stuff.