### PR TITLE
[enhance] Only sync artifacts from list if they exist

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,6 +3,7 @@ host_key_checking = False
 retry_files_enabled = False
 deprecation_warnings = False
 roles_path = ./roles
+stdout_callback = skippy
 
 [paramiko_connection]
 record_host_keys = False

--- a/tasks/builder/sync.yml
+++ b/tasks/builder/sync.yml
@@ -1,10 +1,37 @@
 ---
+- name: Set path to artifacts
+  set_fact:
+    artifact_path: "{{ ansible_env.HOME }}/src/go/src/k8s.io/kubernetes/bazel-bin/build"
+
+- name: Instantiate artifact list
+  set_fact:
+    artifact_list: []
+
+- name: Check if artifact is available
+  stat:
+    path: "{{ artifact_path }}/{{ item }}"
+  register: artifacts_stat_list
+  with_items: "{{ archive_list }}"
+
+- name: Add to artifact list if it exists
+  set_fact:
+    artifact_list: "{{ artifact_list }} + [ '{{ artifact_path }}/{{ item.item }}' ]"
+  with_items: "{{ artifacts_stat_list.results }}"
+  when: item.stat.exists
+
+- name: Notify of any missing artifacts
+  fail:
+    msg: Missing artifact {{ item.item }}
+  with_items: "{{ artifacts_stat_list.results }}"
+  when: not item.stat.exists
+  ignore_fail: True
+
 - name: Synchronize artifacts to kubernetes cluster
   synchronize:
-    src: "{{ ansible_env.HOME }}/src/go/src/k8s.io/kubernetes/bazel-bin/build/{{ item }}"
+    src: "{{ item }}"
     dest: "/tmp/k8s_artifacts/"
     mode: pull
   delegate_to: "{{ k8s_hostname }}"
-  with_items: "{{ archive_list }}"
+  with_items: "{{ artifact_list }}"
   tags:
     - sync_artifacts


### PR DESCRIPTION
Instead of blindly attempting to synchronize artifacts from the
archive_list, check if they are available, and build a list
of the artifacts to sync.

Also provides a fail module output for any of artifacts we expect
to exist, that don't, so it's obvious that things aren't as we
wish them to be. It's likely that if we don't sync all the files
over we expect, that our deploy will fail.

Because this change ends up making the synchronization process quite
a bit noisier when skipping over files, we've migrated to using the
skippy stdout callback module to no longer show skipped commands.

Closes #140