### PR TITLE
Allow k8s ctrlplane listen all interfaces

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -75,6 +75,9 @@ kube_16_workaround: false
 # Kubectl proxy.
 kubectl_proxy_port: 8088
 
+# Allow the kubernetes control plane to listen on all interfaces
+#control_plane_listen_all: true
+
 # --------------------------- -
 # multus-cni vars          - -
 # ------------------------- -

--- a/roles/kube-init/defaults/main.yml
+++ b/roles/kube-init/defaults/main.yml
@@ -2,3 +2,5 @@ kubectl_user: centos
 kubectl_group: centos
 kubectl_home: /home/centos
 artifacts_install: false
+ipv6_enabled: false
+control_plane_listen_all: false

--- a/roles/kube-init/files/kubeadm_control_plane_listen_all.cfg
+++ b/roles/kube-init/files/kubeadm_control_plane_listen_all.cfg
@@ -1,0 +1,6 @@
+apiVersion: kubeadm.k8s.io/v1alpha1
+kind: MasterConfiguration
+controllerManagerExtraArgs:
+  address: 0.0.0.0
+schedulerExtraArgs:
+  address: 0.0.0.0

--- a/roles/kube-init/tasks/main.yml
+++ b/roles/kube-init/tasks/main.yml
@@ -23,10 +23,22 @@
     arg_pod_network: "--config=/root/kubeadm_v6.cfg"
   when: ipv6_enabled
 
+- name: Use config file for control plane listen on all addresses
+  set_fact:
+    arg_pod_network: "--config=/root/kubeadm_control_plane_listen_all.cfg"
+  when: control_plane_listen_all
+
 - name: create kubeadm_v6.cfg
   copy:
     src: kubeadm_v6.cfg
     dest: /root/kubeadm_v6.cfg
+  when: ipv6_enabled
+
+- name: create kubeadm_control_plane_listen_all.cfg
+  copy:
+    src: kubeadm_control_plane_listen_all.cfg
+    dest: /root/kubeadm_control_plane_listen_all.cfg
+  when: control_plane_listen_all
 
 - name: Default cri-o flags to empty
   set_fact:


### PR DESCRIPTION
Allow the Kubernetes control plane to listen on all interfaces.
This change will provide the necessary kubeadm.cfg file to the
kube-init role so that the scheduler and controller pods will listen
on 0.0.0.0 instead of 127.0.0.1 (default).

Closes #176