### PR TITLE
[kubelet] Enable authorization token webhook

### DIFF
--- a/roles/kube-install/tasks/main.yml
+++ b/roles/kube-install/tasks/main.yml
@@ -139,7 +139,7 @@
   lineinfile:
     dest: /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
     regexp: 'systemd$'
-    line: 'ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_SYSTEM_PODS_ARGS $KUBELET_NETWORK_ARGS $KUBELET_DNS_ARGS $KUBELET_AUTHZ_ARGS $KUBELET_EXTRA_ARGS --cgroup-driver=systemd'
+    line: 'ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_SYSTEM_PODS_ARGS $KUBELET_NETWORK_ARGS $KUBELET_DNS_ARGS $KUBELET_AUTHZ_ARGS $KUBELET_EXTRA_ARGS --cgroup-driver=systemd --authentication-token-webhook=true'
   notify: "restart kubelet"
 
 - name: Change cluster dns ip in kubeadm.conf for ipv6


### PR DESCRIPTION
When using an authentication method of Webhook on the kubelet, if you
expose the controller and scheduler outside of 127.0.0.1 then the
scheduler is no longer able to communicate with the API service.

Adding the --authorization-token-webhook=true flag to the kubelet
service seems to mitigate this problem