### PR TITLE
[bugfix] Templates kubeadm config file, includes pod network cidr

### DIFF
--- a/roles/kube-init/tasks/main.yml
+++ b/roles/kube-init/tasks/main.yml
@@ -4,28 +4,28 @@
 #  [root@kube-master centos]# kubeadm --help | grep reset
 #    reset       Run this to revert any changes made to this host by 'kubeadm init' or 'kubeadm join'.
 
-- name: Default pod-network-cidr
+- name: Default primary kubeadm argument
   set_fact:
-    arg_pod_network: ""
+    arg_primary: ""
 
 - name: Set pod-network-cidr when flannel
   set_fact:
-    arg_pod_network: "--pod-network-cidr {{ pod_network_cidr }}/16"
+    arg_primary: "--pod-network-cidr {{ pod_network_cidr }}/16"
   when: pod_network_type != "weave" and not ipv6_enabled
 
 - name: Set apiserver-advertise-address when kokonet-bridge
   set_fact:
-    arg_pod_network: "--apiserver-advertise-address {{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
+    arg_primary: "--apiserver-advertise-address {{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
   when: pod_network_type == "kokonet-bridge"
 
 - name: Use config file for ipv6 for pod-network-cidr
   set_fact:
-    arg_pod_network: "--config=/root/kubeadm_v6.cfg"
+    arg_primary: "--config=/root/kubeadm_v6.cfg"
   when: ipv6_enabled
 
 - name: Use config file for control plane listen on all addresses
   set_fact:
-    arg_pod_network: "--config=/root/kubeadm_control_plane_listen_all.cfg"
+    arg_primary: "--config=/root/kubeadm.cfg"
   when: control_plane_listen_all
 
 - name: create kubeadm_v6.cfg
@@ -34,10 +34,10 @@
     dest: /root/kubeadm_v6.cfg
   when: ipv6_enabled
 
-- name: create kubeadm_control_plane_listen_all.cfg
-  copy:
-    src: kubeadm_control_plane_listen_all.cfg
-    dest: /root/kubeadm_control_plane_listen_all.cfg
+- name: create kubeadm config file
+  template:
+    src: kubeadm.cfg.j2
+    dest: /root/kubeadm.cfg
   when: control_plane_listen_all
 
 - name: Default cri-o flags to empty
@@ -63,7 +63,7 @@
 # abandonded for now...
 - name: Run kubeadm init
   shell: >
-    kubeadm init {{ k8s_version }} {{ arg_crio }} {{ arg_pod_network }} > /var/log/kubeadm.init.log
+    kubeadm init {{ k8s_version }} {{ arg_crio }} {{ arg_primary }} > /var/log/kubeadm.init.log
   args:
     creates: /etc/.kubeadm-complete
 

--- a/roles/kube-init/templates/kubeadm.cfg.j2
+++ b/roles/kube-init/templates/kubeadm.cfg.j2
@@ -1,6 +1,9 @@
+# Full parameters @ https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/
 apiVersion: kubeadm.k8s.io/v1alpha1
 kind: MasterConfiguration
 controllerManagerExtraArgs:
   address: 0.0.0.0
 schedulerExtraArgs:
   address: 0.0.0.0
+networking:
+  podSubnet: {{ pod_network_cidr }}/16


### PR DESCRIPTION
Apparently, the kubeadm config file (according to the [kubeadm init docs](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/)), when presented as an option to `kubeadm init` -- overrides any other flags used for kubeadm init. I first tried to also include the `--pod-network-cidr`, but was given a warning, so I included it in the kubeadm init.

There's probably some further alignment that can be done here for the kubeadm config file in general, but, I took the first step by making it a template. 

I also changed the name of the variable for the "pod network cidr" flag, as it's being used for at least 4 different functions now, just referring to it as `arg_primary` instead of `arg_pod_network`

Fixes #180 