### PR TITLE
Fix bridge network configuration

### DIFF
--- a/roles/bridge-setup/tasks/main.yml
+++ b/roles/bridge-setup/tasks/main.yml
@@ -1,9 +1,29 @@
 ---
 
-- name: Install bridge-utils
+- name: Install bridge-utils and firewalld
   yum:
-    name: bridge-utils
+    name: bridge-utils,firewalld
     state: latest
+
+- name: enable iptables
+  systemd:
+    name: iptables
+    state: started
+    enabled: yes
+
+- name: Accept bridge forwarding and accept packets
+  shell: >
+    firewall-cmd --permanent --direct --passthrough ipv4 -I FORWARD -m physdev --physdev-is-bridged -j ACCEPT;
+    firewall-cmd --direct --passthrough ipv4 -I FORWARD -m physdev --physdev-is-bridged -j ACCEPT;
+    firewall-cmd --permanent --direct --passthrough ipv4 -D INPUT -j REJECT --reject-with icmp-host-prohibited;
+    firewall-cmd --direct --passthrough ipv4 -D INPUT -j REJECT --reject-with icmp-host-prohibited
+
+- name: Enable IPv4 Forwarding
+  sysctl:
+    name: net.ipv4.conf.all.forwarding
+    value: 1
+    sysctl_set: yes
+    state: present
 
 - name: Configure cni0 for control plane
   template:
@@ -17,6 +37,6 @@
   notify: "restart net"
 
 # Note:
-# "restart net" sends DHCP request through eth0 for cni0. 
-# Currently DHCP client will use eth0's MAC, hence IP 
+# "restart net" sends DHCP request through eth0 for cni0.
+# Currently DHCP client will use eth0's MAC, hence IP
 # address should not changed.

--- a/roles/kube-init/tasks/main.yml
+++ b/roles/kube-init/tasks/main.yml
@@ -13,11 +13,6 @@
     arg_primary: "--pod-network-cidr {{ pod_network_cidr }}/16"
   when: pod_network_type != "weave" and not ipv6_enabled
 
-- name: Set apiserver-advertise-address when kokonet-bridge
-  set_fact:
-    arg_primary: "--apiserver-advertise-address {{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
-  when: pod_network_type == "kokonet-bridge"
-
 - name: Use config file for ipv6 for pod-network-cidr
   set_fact:
     arg_primary: "--config=/root/kubeadm_v6.cfg"

--- a/roles/kube-template-cni/templates/bridge.yaml.j2
+++ b/roles/kube-template-cni/templates/bridge.yaml.j2
@@ -19,7 +19,7 @@ data:
       "name": "bridge0",
       "type": "bridge",
       "bridge": "cni0",
-      "hairpiniMode": true, 
+      "hairpinMode": true,
       "ipam": {
         "type": "dhcp",
         "routes": [ { "dst": "0.0.0.0/0" } ]


### PR DESCRIPTION
To run kube with bridge-network, fix iptables, ipv4 forwarding and config file.