### PR TITLE
[multus-crd] Enables Multus with Network Plumbing Working Group CRDs

### DIFF
--- a/inventory/examples/multus/multus-extravars.yml
+++ b/inventory/examples/multus/multus-extravars.yml
@@ -1,0 +1,26 @@
+---
+crd_namespace: "cni.cncf.io"
+multus_use_default_network: true
+# multus_version: "dev/add_ns"
+multus_version: "dev/default_network"
+# multus_version: "develop"
+multus_git_url: "https://github.com/redhat-nfvpe/multus-cni.git"
+bridge_networking: true
+bridge_name: br0
+bridge_physical_nic: "enp1s0f1"
+bridge_network_name: "br0"
+bridge_network_cidr: 192.168.1.0/24
+pod_network_type: "multus"
+virtual_machines:
+  - name: kube-multus-master
+    node_type: master
+  - name: kube-multus-node-1
+    node_type: nodes
+optional_packages:
+  - tcpdump
+  - bind-utils
+multus_use_crd: true
+multus_ipam_subnet: "192.168.1.0/24"
+multus_ipam_rangeStart: "192.168.1.200"
+multus_ipam_rangeEnd: "192.168.1.216"
+multus_ipam_gateway: "192.168.1.1"

--- a/playbooks/ka-init/group_vars/all.yml
+++ b/playbooks/ka-init/group_vars/all.yml
@@ -83,6 +83,10 @@ kubectl_proxy_port: 8088
 # --------------------------- -
 # multus-cni vars          - -
 # ------------------------- -
+# Usually use "master" for multus version, but, otherwise...
+multus_version: master
+multus_use_default_network: false
+multus_git_url: "https://github.com/Intel-Corp/multus-cni.git"
 multus_use_crd: true
 multus_ipam_subnet: "192.168.1.0/24"
 multus_ipam_rangeStart: "192.168.1.200"

--- a/playbooks/ka-multus-cni/multus-cni.yml
+++ b/playbooks/ka-multus-cni/multus-cni.yml
@@ -1,5 +1,12 @@
 ---
+
+- name: Initialize the run 
+  import_playbook: ../ka-init/init.yml
+
+
 - hosts: master,nodes
+  become: true
+  become_user: root
   tasks: []
   roles:
     - { role: multus-cni }

--- a/roles/kube-template-cni/templates/multus-crd.yaml.j2
+++ b/roles/kube-template-cni/templates/multus-crd.yaml.j2
@@ -18,6 +18,16 @@ data:
     {
       "name": "multus-cni-network",
       "type": "multus",
+      "delegates": [
+        {
+          "type": "flannel",
+          "masterplugin": true,
+          "delegate": {
+            "isDefaultGateway": true
+          }
+        }
+      ],{% if multus_use_default_network %}
+      "always_use_default": true,{% endif %}
       "kubeconfig": "/etc/kubernetes/kubelet.conf"
     }
   net-conf.json: |

--- a/roles/multus-cni/tasks/main.yml
+++ b/roles/multus-cni/tasks/main.yml
@@ -8,9 +8,10 @@
 
 - name: Clone multus-cni
   git:
-    repo: https://github.com/Intel-Corp/multus-cni.git
+    repo: "{{ multus_git_url }}"
     dest: /usr/src/multus-cni
-    version: master
+    version: "{{ multus_version }}"
+    force: true
   register: multus_clone
 
 - name: Compile multus-cni
@@ -18,7 +19,7 @@
     ./build
   args:
     chdir: /usr/src/multus-cni
-  when: multus_clone.changed
+  when: multus_clone.changed or force_multus_rebuild is defined
 
 - name: Clone sriov-cni
   git:

--- a/roles/multus-crd/defaults/main.yml
+++ b/roles/multus-crd/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+crd_namespace: "kubernetes.com"

--- a/roles/multus-crd/tasks/main.yml
+++ b/roles/multus-crd/tasks/main.yml
@@ -24,14 +24,18 @@
     kubectl get crd
   register: check_crd
 
+- name: Create network namespace
+  set_fact:
+    use_network_namespace: "network.{{ crd_namespace }}"
+
 - name: Create base CRD
   shell: >
     kubectl create -f {{ ansible_env.HOME }}/multus-resources/multus-crd.yml
-  when: "'networks.kubernetes.com' not in check_crd.stdout"
+  when: "use_network_namespace not in check_crd.stdout"
 
 - name: Check to see which network CRD definitions are present
   shell: >
-    kubectl get networks
+    kubectl get network
   register: check_network_crds
 
 - name: Create flannel network CRD
@@ -46,7 +50,7 @@
 
 - name: Check to see which CRDs are present, for validation
   shell: >
-    kubectl get networks
+    kubectl get network
   register: verify_network_crd
 
 - name: Verify which network CRD definitions are present

--- a/roles/multus-crd/templates/crd.yml.j2
+++ b/roles/multus-crd/templates/crd.yml.j2
@@ -2,10 +2,10 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   # name must match the spec fields below, and be in the form: <plural>.<group>
-  name: networks.kubernetes.com
+  name: networks.{{ crd_namespace }}
 spec:
   # group name to use for REST API: /apis/<group>/<version>
-  group: kubernetes.com
+  group: {{ crd_namespace }}
   # version name to use for REST API: /apis/<group>/<version>
   version: v1
   # either Namespaced or Cluster

--- a/roles/multus-crd/templates/flannel.yml.j2
+++ b/roles/multus-crd/templates/flannel.yml.j2
@@ -1,4 +1,4 @@
-apiVersion: "kubernetes.com/v1"
+apiVersion: "{{ crd_namespace }}/v1"
 kind: Network
 metadata:
   name: flannel-conf

--- a/roles/multus-crd/templates/macvlan.yml.j2
+++ b/roles/multus-crd/templates/macvlan.yml.j2
@@ -1,4 +1,4 @@
-apiVersion: "kubernetes.com/v1"
+apiVersion: "{{ crd_namespace }}/v1"
 kind: Network
 metadata:
   name: macvlan-conf


### PR DESCRIPTION
Allows cloning from alternative git sources for Multus, and includes support of modifications based on network plumbing working group spec.

PR #173 is made unnecessary with this fix.

Fixes #172 