### PR TITLE
[deviceplugins] Adds feature gate parameter to kubelet arguments

### DIFF
--- a/playbooks/ka-init/group_vars/all.yml
+++ b/playbooks/ka-init/group_vars/all.yml
@@ -128,6 +128,11 @@ bridge_network_cidr: 192.168.1.0/24
 ipv6_enabled: false
 
 # ----------------------------
+# device plugins
+# ----------------------------
+enable_device_plugins: false
+
+# ----------------------------
 # builder vars
 # ----------------------------
 

--- a/roles/kube-install/tasks/main.yml
+++ b/roles/kube-install/tasks/main.yml
@@ -135,11 +135,32 @@
     regexp: 'KUBELET_EXTRA_ARGS$'
     state: absent
 
+- name: Default the device plugin parameter to blank
+  set_fact:
+    param_feature_gate: ""
+
+- name: Set the device plugin parameters
+  set_fact:
+    param_feature_gate: "--feature-gates=DevicePlugins=true"
+  when: enable_device_plugins
+
 - name: Add custom kubeadm.conf ExecStart
   lineinfile:
     dest: /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
     regexp: 'systemd$'
-    line: 'ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_SYSTEM_PODS_ARGS $KUBELET_NETWORK_ARGS $KUBELET_DNS_ARGS $KUBELET_AUTHZ_ARGS $KUBELET_EXTRA_ARGS --cgroup-driver=systemd --authentication-token-webhook=true --runtime-cgroups=/systemd/system.slice --kubelet-cgroups=/systemd/system.slice'
+    line: >-
+      ExecStart=/usr/bin/kubelet
+      $KUBELET_KUBECONFIG_ARGS
+      $KUBELET_SYSTEM_PODS_ARGS
+      $KUBELET_NETWORK_ARGS
+      $KUBELET_DNS_ARGS
+      $KUBELET_AUTHZ_ARGS
+      $KUBELET_EXTRA_ARGS
+      --cgroup-driver=systemd
+      --authentication-token-webhook=true
+      --runtime-cgroups=/systemd/system.slice
+      --kubelet-cgroups=/systemd/system.slice
+      {{ param_feature_gate }}
   notify: "restart kubelet"
 
 - name: Change cluster dns ip in kubeadm.conf for ipv6


### PR DESCRIPTION
Enables one to enable the device plugin feature gate, using a `enable_device_plugins` variable, for example to run with kube 1.9.x you may issue something like:

```
ansible-playbook -i inventory/vms.local.generated -e "kube_version=1.9.6-0" -e "enable_device_plugins=true" playbooks/kube-install.yml
```