### PR TITLE
[hotfix] Changes in 17c1b960 result in missing vars

### DIFF
--- a/roles/kubectl-proxy-systemd/defaults/main.yml
+++ b/roles/kubectl-proxy-systemd/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+kubectl_home: /home/centos
+kubectl_user: centos
+kubectl_group: centos


### PR DESCRIPTION
Add back in default values that can be overridden via the change in 17c1b960.
Without these default values, then things fail when you don't define them
statically somewhere else.

Related #219