### PR TITLE
Accounts for the required 'name' parameter in CNI configs

### DIFF
--- a/inventory/examples/multus/v1.multus-extravars.yml
+++ b/inventory/examples/multus/v1.multus-extravars.yml
@@ -1,0 +1,24 @@
+---
+# crd_namespace: "kubernetes.cni.cncf.io"
+# multus_use_default_network: true
+# multus_version: "dev/network-plumbing-working-group-crd-change"
+# multus_git_url: "https://github.com/Intel-Corp/multus-cni.git"
+bridge_networking: true
+bridge_name: br0
+bridge_physical_nic: "enp1s0f1"
+bridge_network_name: "br0"
+bridge_network_cidr: 192.168.1.0/24
+pod_network_type: "multus"
+virtual_machines:
+  - name: kube-multus-master
+    node_type: master
+  - name: kube-multus-node-1
+    node_type: nodes
+optional_packages:
+  - tcpdump
+  - bind-utils
+multus_use_crd: true
+multus_ipam_subnet: "192.168.1.0/24"
+multus_ipam_rangeStart: "192.168.1.200"
+multus_ipam_rangeEnd: "192.168.1.216"
+multus_ipam_gateway: "192.168.1.1"

--- a/roles/kube-template-cni/templates/multus-crd.yaml.j2
+++ b/roles/kube-template-cni/templates/multus-crd.yaml.j2
@@ -31,6 +31,7 @@ data:
       {% else %}
         {
           "type": "flannel",
+          "name": "flannel.1",
           "delegate": {
             "isDefaultGateway": true
           }

--- a/roles/multus-crd/templates/flannel.yml.j2
+++ b/roles/multus-crd/templates/flannel.yml.j2
@@ -4,9 +4,10 @@ metadata:
   name: flannel-conf
 plugin: flannel
 args: '[
-        {
-                "delegate": {
-                        "isDefaultGateway": true
-                }
-        }
+  {
+    "name": "flannel.1",
+    "delegate": {
+      "isDefaultGateway": true
+    }
+  }
 ]'

--- a/roles/multus-crd/templates/macvlan.yml.j2
+++ b/roles/multus-crd/templates/macvlan.yml.j2
@@ -7,6 +7,7 @@ args: '[
         {
             "master": "eth0",
             "mode": "bridge",
+            "name": "macvlan.1",
             "ipam": {
                 "type": "host-local",
                 "subnet": "{{ multus_ipam_subnet }}",


### PR DESCRIPTION
The example configurations for Multus with CRDs (with Multus version 1.0) were missing the `"name":` field which was causing them to not properly come up.

Fixes #232 
