### PR TITLE
Reboot after selinux change (fix #237)

### DIFF
--- a/roles/kube-install/tasks/system_setup.yml
+++ b/roles/kube-install/tasks/system_setup.yml
@@ -3,6 +3,14 @@
   selinux:
     state: disabled
 
+- name: "reboot machine"
+  shell: "sleep 2 && reboot"
+  async: 1
+  poll: 0
+
+- name: "Wait for VM up"
+  local_action: wait_for host={{ inventory_hostname }} port=22 delay=30
+
 - name: "Stop iptables :("
   service:
     name: "{{ __firewall_service }}"


### PR DESCRIPTION
This fix does reboot VMs and wait for reboot due to change selinux
status to 'disabled' because reboot is required to change selinux
status to 'disabled' and CoreDNS needs the change, too.