### PR TITLE
Support cri-o with kuberentes 1.11 in Fedora

### DIFF
--- a/docs/additional_scenarios_and_usage.md
+++ b/docs/additional_scenarios_and_usage.md
@@ -50,6 +50,7 @@ an extra var when you run the playbook:
 
 ```
 $ ansible-playbook -i inventory/vms.local.generated \
+    -e 'ansible_python_interpreter=/usr/bin/python3' \
     -e 'container_runtime=crio' \
     playbooks/kube-install.yml
 ```

--- a/inventory/examples/crio/crio.inventory
+++ b/inventory/examples/crio/crio.inventory
@@ -36,3 +36,7 @@ kubectl_user=fedora
 kubectl_group=fedora
 # Using CRI-O (you must set this as an extra var, e.g. `-e "container_runtime=crio"`)
 # container_runtime=crio
+
+# Need to set crio_versions for installed kubernetes version, see following URL for details.
+# https://github.com/kubernetes-incubator/cri-o#compatibility-matrix-cri-o---kubernetes-clusters
+# crio_versions=v1.11.1

--- a/playbooks/ka-init/group_vars/all.yml
+++ b/playbooks/ka-init/group_vars/all.yml
@@ -7,7 +7,7 @@ container_runtime: docker
 
 # Which version of crio?
 # (doesn't matter if docker is container runtime)
-crio_version: v1.0.0-rc1
+crio_version: v1.11.1
 
 # Pod net work types
 # A value of "none" will create no networking and will not join nodes to cluster.

--- a/playbooks/kube-install.yml
+++ b/playbooks/kube-install.yml
@@ -30,6 +30,9 @@
   tasks:
     - name: Set bridge-nf-call-iptables to 1
       shell: >
+        if [ ! -f /proc/sys/net/bridge/bridge-nf-call-iptables ]; then \
+          modprobe br_netfilter; \
+        fi && \
         echo "1" > /proc/sys/net/bridge/bridge-nf-call-iptables
 
 - hosts: master

--- a/roles/buildah-install/tasks/main.yml
+++ b/roles/buildah-install/tasks/main.yml
@@ -30,6 +30,7 @@
 
 - name: Build Buildah, it's a dollah twenty five pah.
   shell: >
+    export GOPATH={{ ansible_env.HOME}}/{{ gopath }} && \
     make && make install
   args:
     chdir: "{{ ansible_env.HOME }}/{{ gopath }}/src/github.com/projectatomic/buildah"

--- a/roles/cri-o-install/tasks/install.yml
+++ b/roles/cri-o-install/tasks/install.yml
@@ -46,26 +46,26 @@
 - name: clone runc
   git:
     repo: https://github.com/opencontainers/runc
-    dest: "{{ ansible_env.HOME }}/{{ gopath }}/github.com/opencontainers/runc"
+    dest: "{{ ansible_env.HOME }}/{{ gopath }}/src/github.com/opencontainers/runc"
     version: master
 
 - name: clone CRI-O
   git:
     repo: https://github.com/kubernetes-incubator/cri-o
-    dest: "{{ ansible_env.HOME }}/{{ gopath }}/github.com/kubernetes-incubator/cri-o"
+    dest: "{{ ansible_env.HOME }}/{{ gopath }}/src/github.com/kubernetes-incubator/cri-o"
     version: "{{ crio_version }}"
 
 - name: clone CNI
   git:
     repo: https://github.com/containernetworking/plugins
-    dest: "{{ ansible_env.HOME }}/{{ gopath }}/github.com/containernetworking/plugins"
+    dest: "{{ ansible_env.HOME }}/{{ gopath }}/src/github.com/containernetworking/plugins"
     version: master
 
 - name: build runc
   shell: |
-          cd {{ ansible_env.HOME }}/{{ gopath }}/github.com/opencontainers/runc && \
-          make BUILDTAGS="seccomp selinux" && \
-          make install
+          cd {{ ansible_env.HOME }}/{{ gopath }}/src/github.com/opencontainers/runc && \
+          export GOPATH={{ ansible_env.HOME}}/{{ gopath }} && \
+          make BUILDTAGS="seccomp selinux" && make install
   environment:
     PATH: "{{ extended_path }}"
 
@@ -77,7 +77,7 @@
 
 - name: build cri-o
   shell: |
-          cd {{ ansible_env.HOME }}/{{ gopath }}/github.com/kubernetes-incubator/cri-o && \
+          cd {{ ansible_env.HOME }}/{{ gopath }}/src/github.com/kubernetes-incubator/cri-o && \
           make install.tools && \
           make && \
           make install && \
@@ -88,7 +88,7 @@
 
 - name: build CNI stuff
   shell: |
-          cd {{ ansible_env.HOME }}/{{ gopath }}/github.com/containernetworking/plugins && \
+          cd {{ ansible_env.HOME }}/{{ gopath }}/src/github.com/containernetworking/plugins && \
           ./build.sh && \
           mkdir -p /opt/cni/bin && \
           cp bin/* /opt/cni/bin/
@@ -104,7 +104,7 @@
 
 - name: run with overlay2
   replace:
-    regexp: 'storage_driver = ""'
+    regexp: '^#storage_driver = "overlay"'
     replace: 'storage_driver = "overlay2"'
     name: /etc/crio/crio.conf
     backup: yes
@@ -112,10 +112,20 @@
 - name: add overlay2 storage opts on RHEL/CentOS
   lineinfile:
     dest: /etc/crio/crio.conf
-    line: '"overlay2.override_kernel_check=1"'
-    insertafter: 'storage_option = \['
-    regexp: 'overlay2\.override_kernel_check=1'
+    line: "{{ item }}"
+    insertbefore: '^#storage_option = \['
     state: present
+  with_items:
+    - 'storage_option = ['
+    - '"overlay2.override_kernel_check=true",'
+    - ']'
+
+- name: change runtime (runc) path
+  replace:
+    regexp: '^runtime =.*$'
+    replace: 'runtime = "/usr/local/sbin/runc"'
+    name: /etc/crio/crio.conf
+    backup: yes
 
 - name: enable and start CRI-O
   systemd:
@@ -145,7 +155,7 @@
 - name: systemd dropin for kubeadm
   shell: |
           sh -c 'echo "[Service]
-          Environment=\"KUBELET_EXTRA_ARGS=--container-runtime=remote --runtime-request-timeout=15m --image-service-endpoint /var/run/crio.sock --container-runtime-endpoint /var/run/crio.sock\"" > /etc/systemd/system/kubelet.service.d/0-crio.conf'
+          Environment=\"KUBELET_EXTRA_ARGS=--container-runtime=remote --runtime-request-timeout=15m --image-service-endpoint /var/run/crio/crio.sock --container-runtime-endpoint /var/run/crio/crio.sock\"" > /etc/systemd/system/kubelet.service.d/0-crio.conf'
 
 - name: flush iptables
   command: "iptables -F"

--- a/roles/kube-common/defaults/main.yml
+++ b/roles/kube-common/defaults/main.yml
@@ -7,7 +7,7 @@ container_runtime: docker
 
 # Which version of crio?
 # (doesn't matter if docker is container runtime)
-crio_version: v1.0.0-rc1
+crio_version: v1.11.1
 
 # Pod net work types
 # A value of "none" will create no networking and will not join nodes to cluster.

--- a/roles/kube-init/tasks/main.yml
+++ b/roles/kube-init/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: Set cri-o flags
   set_fact:
-    arg_crio: "--skip-preflight-checks"
+    arg_crio: "--ignore-preflight-errors=all"
   when: container_runtime == "crio"
 
 - name: Default k8s version to empty

--- a/roles/kube-init/templates/kubeadm.cfg.j2
+++ b/roles/kube-init/templates/kubeadm.cfg.j2
@@ -32,3 +32,6 @@ kubeletConfiguration:
     # kubeletCgroups: /systemd/system.slice
     # unsure if this fits for: runtime-cgroups
     # systemCgroups: /systemd/system.slice
+{% if container_runtime == "crio" %}
+criSocket: /var/run/crio/crio.sock
+{% endif %}

--- a/roles/kube-install/vars/RedHat-26.yml
+++ b/roles/kube-install/vars/RedHat-26.yml
@@ -1,0 +1,2 @@
+---
+__firewall_service: iptables

--- a/roles/kube-join-cluster/tasks/main.yml
+++ b/roles/kube-join-cluster/tasks/main.yml
@@ -1,10 +1,15 @@
 ---
 # - debug: "msg={{ kubeadm_join_command }}"
 
+- name: Set skip_preflight_checks args if need be.
+  set_fact:
+    arg_crio: "--ignore-preflight-errors=all"
+  when: skip_preflight_checks
+
 - name: Set cri-o args if need be.
   set_fact:
-    arg_crio: "--skip-preflight-checks"
-  when: container_runtime == "crio" or skip_preflight_checks
+    arg_crio: "--ignore-preflight-errors=all --cri-socket=\\/var\\/run\\/crio\\/crio.sock"
+  when: container_runtime == "crio"
 
 - name: Change the given command
   shell: >


### PR DESCRIPTION
Change the followings for cri-o support in k8s v1.11:
+ Fix cri-o related go code path
+ Fix /etc/crio/crio.conf to latest crio
+ Change '--skip-preflight-checkes for its deprecation
+ Add crio related option in kubeadm init/join