### PR TITLE
Correct pathname to group vars file referenced in documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ and virtual hosts.
 
 Want more VMs? Edit `inventory/virthost/group_vars/virthost.yml` and add an
 override list via `virtual_machines` (template in
-`roles/ka-init/group_vars/all.yml`). You can also define separate vCPU and vRAM
+`playbooks/ka-init/group_vars/all.yml`). You can also define separate vCPU and vRAM
 for each of the virtual machines with `system_ram_mb` and `system_cpus`. The
 default values are setup via `system_default_ram_mb` and `system_default_cpus`
 which can also be overridden if you wish different default values. (Current


### PR DESCRIPTION
This is a minor fix in the README correcting a path name reference.

Signed-off-by: Thomas F Herbert <therbert@redhat.com>