### PR TITLE
Correct the name of the group variable containing

### DIFF
--- a/inventory/examples/bmhost/bmhost.inventory
+++ b/inventory/examples/bmhost/bmhost.inventory
@@ -1,5 +1,5 @@
 bmhost ansible_host=10.8.125.31 ansible_ssh_user=therbert
 
-[bmhost]
+[bmhosts]
 bmhost
 


### PR DESCRIPTION
Correct the name of the group variable containing the names of bare metal hosts.

Signed-off-by: Thomas F Herbert <therbert@redhat.com>