### PR TITLE
Updates for apiVersion v1

### DIFF
--- a/roles/glusterfs-kube-config/templates/glusterfs-storageclass.yaml.j2
+++ b/roles/glusterfs-kube-config/templates/glusterfs-storageclass.yaml.j2
@@ -1,6 +1,6 @@
 {% for storageclass in gluster_storageclasses %}
 ---
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: {{ storageclass.metadata.name }}

--- a/roles/kube-init/tasks/main.yml
+++ b/roles/kube-init/tasks/main.yml
@@ -38,6 +38,12 @@
         dest: /root/kubeadm.cfg
       when: kubeadm_version_minor.stdout|int >= 13
 
+    - name: create kubeadm config file (>= 1.16)
+      template:
+        src: kubeadm.cfg.v1beta2.j2
+        dest: /root/kubeadm.cfg
+      when: kubeadm_version_minor.stdout|int >= 16
+
 - name: Default cri-o flags to empty
   set_fact:
     arg_crio: ""

--- a/roles/kube-init/templates/kubeadm.cfg.v1beta2.j2
+++ b/roles/kube-init/templates/kubeadm.cfg.v1beta2.j2
@@ -1,0 +1,34 @@
+# Full parameters @ https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/
+# for v1.13 (https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta1)
+kind: ClusterConfiguration
+apiVersion: kubeadm.k8s.io/v1beta2
+apiServer:
+  extraArgs:
+    enable-admission-plugins: NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
+networking:
+  podSubnet: {{ pod_network_cidr }}/16
+{% if control_plane_listen_all %}
+controllerManager:
+  extraArgs:
+    address: 0.0.0.0
+scheduler:
+  extraArgs:
+    address: 0.0.0.0
+{% endif %}
+{% if enable_device_plugins %}
+featureGates:
+  DevicePlugins: true
+{% endif %}
+---
+kind: InitConfiguration
+apiVersion: kubeadm.k8s.io/v1beta2
+{% if container_runtime == "crio" %}
+nodeRegistration:
+  criSocket: /var/run/crio/crio.sock
+{% endif %}
+---
+kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1
+{% if container_runtime == "crio" %}
+cgroupDriver: systemd
+{% endif %}

--- a/roles/kube-template-cni/templates/bridge.yaml.j2
+++ b/roles/kube-template-cni/templates/bridge.yaml.j2
@@ -42,7 +42,7 @@ data:
       ]
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-bridge-ds
@@ -51,6 +51,9 @@ metadata:
     tier: node
     app: bridge
 spec:
+  selector:
+    matchLabels:
+      app: bridge
   template:
     metadata:
       labels:

--- a/roles/kube-template-cni/templates/calico-rbac.yaml.j2
+++ b/roles/kube-template-cni/templates/calico-rbac.yaml.j2
@@ -1,7 +1,7 @@
 # Calico Version v3.1.3
 # https://docs.projectcalico.org/v3.1/releases#v3.1.3
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-node
 rules:
@@ -78,7 +78,7 @@ rules:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: calico-node

--- a/roles/kube-template-cni/templates/calico.yaml.j2
+++ b/roles/kube-template-cni/templates/calico.yaml.j2
@@ -72,7 +72,7 @@ spec:
 
 # This manifest creates a Deployment of Typha to back the above service.
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: calico-typha
@@ -154,7 +154,7 @@ spec:
 # as the Calico CNI plugins and network config on
 # each master and worker node in a Kubernetes cluster.
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: calico-node
   namespace: kube-system
@@ -326,7 +326,7 @@ spec:
 # Calico policy and networking mode.
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
    name: felixconfigurations.crd.projectcalico.org
@@ -341,7 +341,7 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: bgppeers.crd.projectcalico.org
@@ -356,7 +356,7 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
@@ -371,7 +371,7 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
@@ -386,7 +386,7 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: hostendpoints.crd.projectcalico.org
@@ -401,7 +401,7 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
@@ -416,7 +416,7 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
@@ -431,7 +431,7 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org
@@ -446,7 +446,7 @@ spec:
 
 ---
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org

--- a/roles/kube-template-cni/templates/flannel-rbac.yaml.j2
+++ b/roles/kube-template-cni/templates/flannel-rbac.yaml.j2
@@ -1,6 +1,6 @@
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
 rules:
@@ -25,7 +25,7 @@ rules:
       - patch
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
 roleRef:

--- a/roles/kube-template-cni/templates/flannel.yaml.j2
+++ b/roles/kube-template-cni/templates/flannel.yaml.j2
@@ -19,6 +19,7 @@ data:
   cni-conf.json: |
     {
       "name": "cbr0",
+      "cniVersion": "0.2.0",
       "plugins": [
         {
           "type": "flannel",
@@ -43,7 +44,7 @@ data:
       }
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-flannel-ds
@@ -52,6 +53,9 @@ metadata:
     tier: node
     app: flannel
 spec:
+  selector:
+    matchLabels:
+      app: flannel
   template:
     metadata:
       labels:

--- a/roles/kube-template-cni/templates/multus-crd.yaml.j2
+++ b/roles/kube-template-cni/templates/multus-crd.yaml.j2
@@ -42,7 +42,7 @@ data:
       }
     }
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: kube-multus-ds
@@ -51,6 +51,9 @@ metadata:
     tier: node
     app: multus
 spec:
+  selector:
+    matchLabels:
+      app: kube-multus-ds
   template:
     metadata:
       labels:


### PR DESCRIPTION
Updates for apiVersion v1
 Also fixed cniVersion where required to 0.2.0
kubeadm config is updated to v1beta2 except kubelet which remains at v1beta1.


Signed-off-by: Thomas F Herbert <therbert@redhat.com>