### PR TITLE
Bypass kubeadm reset confirmation

### DIFF
--- a/roles/kube-teardown/tasks/main.yml
+++ b/roles/kube-teardown/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Teardown kube nodes
   shell: >
-    kubeadm reset
+    kubeadm reset -f
 
 - name: Remove all semaphores
   file:


### PR DESCRIPTION
Fixes problem where kubeadm reset command was hanging because it
was waiting for user to confirm.

Signed-off-by: Thomas F Herbert <therbert@redhat.com>