### PR TITLE
Add 'none-2nics' network type, just for 2nics env without CNI setup

### DIFF
--- a/playbooks/kube-install.yml
+++ b/playbooks/kube-install.yml
@@ -6,7 +6,7 @@
   become_user: root
   tasks: []
   roles:
-    - { role: multus-2nics-setup, when: pod_network_type == 'multus-2nics' }
+    - { role: multus-2nics-setup, when: pod_network_type == 'multus-2nics' or pod_network_type == 'none-2nics' }
     - { role: bridge-setup, when: pod_network_type == 'bridge' }
     - { role: optional-packages }
     # You can add "crio_force: true" if you need to run the builds again.
@@ -41,7 +41,7 @@
 - hosts: master
   tasks: []
   roles:
-    - { role: kube-cni, when : "pod_network_type != 'none'" }
+    - { role: kube-cni, when : "pod_network_type != 'none' and pod_network_type != 'none-2nics'" }
     - { role: kube-niceties }
 
 - hosts: nodes


### PR DESCRIPTION
Depends on https://github.com/redhat-nfvpe/ansible-role-vm-spinup/pull/42