### PR TITLE
Change default RAM to 4G

### DIFF
--- a/playbooks/ka-init/group_vars/all.yml
+++ b/playbooks/ka-init/group_vars/all.yml
@@ -55,7 +55,7 @@ kube_version: "latest"
 # binary_install_force_redownload: false
 
 images_directory: /home/images
-system_default_ram_mb: 2048
+system_default_ram_mb: 4096
 system_default_cpus: 4
 virtual_machines:
   - name: kube-master


### PR DESCRIPTION
In OVN case or some environment which requires a lot of memory,
current RAM is not enough, hence change to 4G as default.