### PR TITLE
Add cri-o(and related pkgs) copr install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ kube-ansible supports following options
   - `bridge`: add linux bridge (`cni0`) and move `eth0` under `cni0`. This is useful to use linux bridge CNI for Kubernetes Pod's network
 - `container_runtime`: sepcify container runtime that Kubernetess uses. Default uses Docker.
   - `crio`: install [cri-o](https://cri-o.io/) for the container runtime
+- `crio_use_copr`: (only in case of cri-o) set true if [copr cri-o RPM](http://copr.fedorainfracloud.org/coprs/s1061123/cri-o) is used
 - 'enable_endpointslice': set true if endpointslice is used instead of endpoints
 
 Here's the example:

--- a/playbooks/ka-init/group_vars/all.yml
+++ b/playbooks/ka-init/group_vars/all.yml
@@ -23,6 +23,7 @@ docker_install_suppress_newgrp: true
 # (doesn't matter if docker is container runtime)
 crio_build_version: v1.11.1
 crio_build_install: False
+crio_use_copr: True
 crio_baseurl: https://cbs.centos.org/repos/paas7-crio-115-candidate/x86_64/os
 
 # Pod net work CIDR

--- a/roles/cri-o-install/tasks/main.yml
+++ b/roles/cri-o-install/tasks/main.yml
@@ -14,7 +14,11 @@
 - name: Include the crio install plays
   block:
     - name: Get package and install crio
-      include: pkg_install.yml
+      block:
+        - include: pkg_install.yml
+          when: not crio_use_copr|bool
+        - include: pkg_copr_install.yml
+          when: crio_use_copr|bool
       when: not crio_build_install|bool
     - name: Build and install crio
       include: build_install.yml

--- a/roles/cri-o-install/tasks/pkg_copr_install.yml
+++ b/roles/cri-o-install/tasks/pkg_copr_install.yml
@@ -1,0 +1,98 @@
+---
+# Some (lots!) borrowed from https://github.com/cri-o/cri-o-ansible
+
+- name: install copr plugin
+  yum:
+    name: yum-plugin-copr
+    state: present
+    disable_gpg_check: yes
+
+- name: yum-enable-copr
+  block:
+    - name: enable conmon
+      command: yum copr enable -y s1061123/conmon
+      args:
+        warn: no
+    - name: enable cri-o
+      command: yum copr enable -y s1061123/cri-o
+      args:
+        warn: no
+    - name: enable cri-tools
+      command: yum copr enable -y s1061123/cri-tools
+      args:
+        warn: no
+
+- name: Install CRI-O/conmon/critools
+  block:
+    - name: conmon
+      yum:
+        name: conmon
+        state: present
+        disable_gpg_check: yes
+    - name: cri-o
+      yum:
+        name: cri-o
+        state: present
+        disable_gpg_check: yes
+    - name: cri-tools
+      yum:
+        name: cri-tools
+        state: present
+        disable_gpg_check: yes
+
+- name: enable and start CRI-O
+  systemd:
+    name: crio
+    state: started
+    enabled: yes
+    daemon_reload: yes
+
+- name: remove default CNI for further k8s cni plugin install
+  file:
+    path: /etc/cni/net.d
+    state: absent
+
+- name: re-create default CNI for further k8s cni plugin install
+  file:
+    path: /etc/cni/net.d
+    state: directory
+
+- name: modprobe br_netfilter
+  command: "modprobe br_netfilter"
+  ignore_errors: true
+
+# TODO: see if we can switch to the 'sysctl' module here
+- name: tune sysctl
+  lineinfile:
+    line: "net/bridge/bridge-nf-call-iptables = 1"
+    dest: /etc/sysctl.conf
+    insertafter: 'EOF'
+    regexp: '\/net\/bridge\/bridge-nf-call-iptables = 1'
+    state: present
+  ignore_errors: true
+
+- name: reload sysctl
+  command: "sysctl -p"
+  ignore_errors: true
+
+- name: Make directories
+  file:
+    path: "{{ item }}"
+    state: directory
+  with_items:
+       - /etc/systemd/system/kubelet.service.d/
+
+- name: systemd dropin for kubeadm
+  shell: |
+          sh -c 'echo "[Service]
+          Environment=\"KUBELET_EXTRA_ARGS=--cgroup-driver=systemd --container-runtime=remote --runtime-request-timeout=15m --image-service-endpoint /var/run/crio/crio.sock --container-runtime-endpoint /var/run/crio/crio.sock\"" > /etc/systemd/system/kubelet.service.d/0-crio.conf'
+
+- name: flush iptables
+  command: "iptables -F"
+
+- name: enable and start CRI-O
+  systemd:
+    name: crio
+    state: restarted
+    enabled: yes
+    daemon_reload: yes


### PR DESCRIPTION
This change adds 'crio_use_copr' variable to use copr pkgs
for cri-o install, instead of PAAS CRI-O repo. This is also
make it default because this repo no longer updated.