### PR TITLE
kube-install-ovn : kubernetes installation fails

### DIFF
--- a/roles/lb-setup/tasks/main.yml
+++ b/roles/lb-setup/tasks/main.yml
@@ -8,7 +8,8 @@
     state: present
 
 - name: check if haproxy config file exist
-  stat path="/etc/haproxy/haproxy.cfg"
+  stat:
+    path: /etc/haproxy/haproxy.cfg
   register: file_status
   delegate_to: localhost
 

--- a/roles/lb-setup/tasks/main.yml
+++ b/roles/lb-setup/tasks/main.yml
@@ -8,9 +8,9 @@
     state: present
 
 - name: check if haproxy config file exist
-  local_action:
-    stat path="/etc/haproxy/haproxy.cfg"
+  stat path="/etc/haproxy/haproxy.cfg"
   register: file_status
+  delegate_to: localhost
 
 - name: backup original
   copy:

--- a/roles/lb-setup/tasks/main.yml
+++ b/roles/lb-setup/tasks/main.yml
@@ -7,10 +7,16 @@
     name: haproxy
     state: present
 
+- name: check if haproxy config file exist
+  local_action:
+    stat path="/etc/haproxy/haproxy.cfg"
+  register: file_status
+
 - name: backup original
   copy:
     src: /etc/haproxy/haproxy.cfg
     dest: /etc/haproxy/haproxy.cfg.orig
+  when: file_status.stat.exists
 
 - name: create haproxy.cfg
   template:


### PR DESCRIPTION
because haproxy.cfg does not exist

kube-install-ovn, tries to backup the haproxy.cfg file
and fails. It fails because in the fresh installation
there is no existing haproxy.cfg file exist. This patch
adds pre-check task to check the existance of the file,
and removes if file already exists.

Resolves : #318
Signed-off-by: Anil Vishnoi <vishnoianil@gmail.com>