### PR TITLE
Do not install ovn related packages

### DIFF
--- a/roles/ovn-setup/tasks/main.yml
+++ b/roles/ovn-setup/tasks/main.yml
@@ -25,7 +25,7 @@
         reboot_timeout: 600
   when: ansible_kernel is  version('4.6','<')
 
-- name: install openvswitch/ovn
+- name: install openvswitch and required dependencies on the master/worker nodes
   block:
     - name: install openstack repo
       yum_repository:
@@ -34,13 +34,10 @@
         file: cloud7-openstack-train-release
         baseurl: https://cbs.centos.org/repos/cloud7-openstack-train-release/x86_64/os
         gpgcheck: no
-    - name: install openvswitch and so on
+    - name: install openvswitch
       yum:
         name:
-          - ovn
-          - ovn-central
-          - ovn-vtep
-          - ovn-host
+          - openvswitch
         enablerepo: cloud7-openstack-train-release
         state: present
     - name: install libibverbs


### PR DESCRIPTION
(ovn,ovn-host,ovn-central,ovn-vtep) in virtual host.

These packages are not required at the virtual host.
ovn-kubernetes docker image contains the latest
supported ovn related binaries that is being used
by he deployment.
Resolves: #321

Signed-off-by: Anil Vishnoi <vishnoianil@gmail.com>