### PR TITLE
Update .gitignore to not track the logfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ roles/auto-kube-dev
 roles/redhat-nfvpe.vm-spinup
 roles/redhat-nfvpe.prometheus-operator
 roles/oVirt.*
+
+#ignore locally generated logfile
+logfile


### PR DESCRIPTION
kube-ansible playbooks installation logs goes to logfile, and git keep tracking that file, which is not required.
Signed-off-by: Anil Vishnoi <vishnoianil@gmail.com>