### PR TITLE
Configure kubectl for all the master nodes in cluster

### DIFF
--- a/playbooks/kube-install-ovn.yml
+++ b/playbooks/kube-install-ovn.yml
@@ -52,6 +52,8 @@
   tasks: []
   roles:
     - { role: kube-init }
+    - { role: configure-kubectl }
+
 
 - hosts: master_slave
   become: true
@@ -66,11 +68,13 @@
   tasks: []
   roles:
     - { role: kube-master-join-cluster }
+    - { role: configure-kubectl }
+
 
 # ---- placeholder: kube-cni
 # without become.
 
-- hosts: master
+- hosts: master, master_slave
   tasks: []
   roles:
     - { role: kube-niceties }

--- a/playbooks/kube-install.yml
+++ b/playbooks/kube-install.yml
@@ -51,6 +51,7 @@
   tasks: []
   roles:
     - { role: kube-init }
+    - { role: configure-kubectl }
 
 - hosts: master_slave
   become: true
@@ -65,9 +66,10 @@
   tasks: []
   roles:
     - { role: kube-master-join-cluster }
+    - { role: configure-kubectl }
 
 # without become.
-- hosts: master
+- hosts: master, master_slave
   tasks: []
   roles:
     - { role: kube-niceties }

--- a/roles/configure-kubectl/defaults/main.yml
+++ b/roles/configure-kubectl/defaults/main.yml
@@ -1,0 +1,3 @@
+kubectl_user: centos
+kubectl_group: centos
+kubectl_home: /home/centos

--- a/roles/configure-kubectl/tasks/main.yml
+++ b/roles/configure-kubectl/tasks/main.yml
@@ -1,0 +1,31 @@
+# -------- Configure kubectl -------------
+# It does the following
+# sudo cp /etc/kubernetes/admin.conf $HOME/.kube
+# sudo chown $(id -u):$(id -g) $HOME/.kube/admin.conf
+# export KUBECONFIG=$HOME/.kube/admin.conf
+
+- name: Ensure .kube folder exists
+  file:
+    path: "{{ kubectl_home }}/.kube/"
+    state: directory
+    owner: "{{ kubectl_user }}"
+    group: "{{ kubectl_group }}"
+    mode: 0755
+
+- name: Copy admin.conf to kubectl user's home
+  shell: >
+    cp -f /etc/kubernetes/admin.conf {{ kubectl_home }}/.kube/admin.conf
+  args:
+    creates: "{{ kubectl_home }}/admin.conf"
+
+- name: Set admin.conf ownership
+  file:
+    path: "{{ kubectl_home }}/.kube/admin.conf"
+    owner: "{{ kubectl_user }}"
+    group: "{{ kubectl_group }}"
+
+- name: Add KUBECONFIG env for admin.conf to .bashrc
+  lineinfile:
+    dest: "{{ kubectl_home }}/.bashrc"
+    regexp: "KUBECONFIG"
+    line: "export KUBECONFIG={{ kubectl_home }}/.kube/admin.conf"

--- a/roles/kube-init/defaults/main.yml
+++ b/roles/kube-init/defaults/main.yml
@@ -1,4 +1,1 @@
-kubectl_user: centos
-kubectl_group: centos
-kubectl_home: /home/centos
 control_plane_listen_all: false

--- a/roles/kube-init/tasks/main.yml
+++ b/roles/kube-init/tasks/main.yml
@@ -112,36 +112,3 @@
   set_fact:
     kubeadm_cert_key: "{{ kubeadm_cert_key_output.stdout }}"
   when: groups.master_slave is defined and groups.master_slave|length > 0
-# -------- Copy in admin.conf
-
-# ---- Kube 1.6, apparently you can't use kubectl as root? weird/awesome.
-
-  # sudo cp /etc/kubernetes/admin.conf $HOME/
-  # sudo chown $(id -u):$(id -g) $HOME/admin.conf
-  # export KUBECONFIG=$HOME/admin.conf
-
-- name: Ensure .kube folder exists
-  file:
-    path: "{{ kubectl_home }}/.kube/"
-    state: directory
-    owner: "{{ kubectl_user }}"
-    group: "{{ kubectl_group }}"
-    mode: 0755
-
-- name: Copy admin.conf to kubectl user's home
-  shell: >
-    cp -f /etc/kubernetes/admin.conf {{ kubectl_home }}/.kube/admin.conf
-  args:
-    creates: "{{ kubectl_home }}/admin.conf"
-
-- name: Set admin.conf ownership
-  file:
-    path: "{{ kubectl_home }}/.kube/admin.conf"
-    owner: "{{ kubectl_user }}"
-    group: "{{ kubectl_group }}"
-
-- name: Add KUBECONFIG env for admin.conf to .bashrc
-  lineinfile:
-    dest: "{{ kubectl_home }}/.bashrc"
-    regexp: "KUBECONFIG"
-    line: "export KUBECONFIG={{ kubectl_home }}/.kube/admin.conf"


### PR DESCRIPTION
Currently only primary master node is configured to use kubectl
out of the box. If user login to any of the secondary masters,
to make kubectl work, explicit configuration is required e.g (set KUBECONFIG to admin.conf).

Resolves: #326
Signed-off-by: Anil Vishnoi <vishnoianil@gmail.com>