### PR TITLE
OVN kubernetes does not require kube-proxy

### DIFF
--- a/playbooks/kube-install-ovn.yml
+++ b/playbooks/kube-install-ovn.yml
@@ -88,13 +88,6 @@
 
 - hosts: master
   become: true
-  become_user: root
-  tasks: []
-  roles:
-    - { role: kubectl-proxy-systemd }
-
-- hosts: master
-  become: true
   become_user: centos
   tasks: []
   roles:

--- a/roles/ovnkube-setup/tasks/main.yml
+++ b/roles/ovnkube-setup/tasks/main.yml
@@ -60,6 +60,6 @@
     - ovnkube-node.yaml
   when: enable_ovn_raft is not defined and not enable_ovn_raft
 
-- name: Stop kube-proxy daemonset
+- name: Stop kube-proxy daemonset  # noqa 301
   command: kubectl -n kube-system delete ds kube-proxy
   failed_when: false

--- a/roles/ovnkube-setup/tasks/main.yml
+++ b/roles/ovnkube-setup/tasks/main.yml
@@ -59,3 +59,7 @@
     - ovnkube-master.yaml
     - ovnkube-node.yaml
   when: enable_ovn_raft is not defined and not enable_ovn_raft
+
+- name: Stop kube-proxy daemonset
+  command: kubectl -n kube-system delete ds kube-proxy
+  failed_when: false


### PR DESCRIPTION
So stop the kube-proxy daemon once OVN kuberentes CNI
is deployed and up

Resolves: #329
Signed-off-by: Anil Vishnoi <vishnoianil@gmail.com>