### PR TITLE
Quick teardown and creation of VMs can cause stale dns entires in VMs.

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -30,5 +30,6 @@ address from `getent ahostsv4 <hostname>` & `ifconfig` on that host, it means yo
 
 **Workaround** Make sure that the dnsmasq service is in correct state on your physical machine where libvirt is running.
 Fire `pkill -HUP dnsmasq` on the physical machine, it will result in `dnsmasq` loading the fresh configuration and
-now `getent ahostsv4 <hostname>` should in VM should show the same ip address as `ifconfig`. Once DNS caches are refresh,
+now `getent ahostsv4 <hostname>` in VM should show the same ip address as `ifconfig`. Once DNS cache is refreshed,
  you can trigger the ansible-playbook that installs the k8s deployment.
+ ***Note*** This workaround is already part kube-ansible playbook. If you want to skip this workaround please run `virthost.yml` playbook with `--skip-tags dns-workaround`.

--- a/playbooks/virthost-setup.yml
+++ b/playbooks/virthost-setup.yml
@@ -2,7 +2,14 @@
 - import_playbook: ka-init/init.yml
 
 - hosts: virthost
-  tasks: []
+  tasks:
+    - name: Reload dnsmasq config, so that VM's DNS cache can be refreshed.
+      block:
+        - debug:
+            msg: "Reloading dnsmasq config."
+        - name: Reload dnsmasq config
+          command: pkill -HUP dnsmasq
+      tags: dns-workaround
 
   roles:
     - { role: redhat-nfvpe.vm-spinup }


### PR DESCRIPTION
If user tear down the VMs and recreate the VMs again shortly,
newly created VMs might retain the stale dns cache entry
for hostname (mapping to previosly created VM's IP address).
This causes issue with the OVN kubernetes setup because it
relies on - $ getent ahostsv4 <hostname>- command
to get the host ip address and that returnes the
stale IP address for the hostname and that results
in cluster setup failure.

This Patch provides the workaround fix that will
reload the dnsmasq configuration once VMs are
created so VMs DNS cache gets the latest dns records.

Signed-off-by: Anil Vishnoi <vishnoianil@gmail.com>