### PR TITLE
OVN-kubernetes PR broke kube-ansible project

### DIFF
--- a/roles/ovnkube-setup/tasks/main.yml
+++ b/roles/ovnkube-setup/tasks/main.yml
@@ -32,7 +32,7 @@
         chdir: $HOME/work/src/github.com/ovn-org/ovn-kubernetes/dist/images
 
 - name: Add label to master node for ovn raft mode
-  command: kubectl label nodes {{ item }} ovn.org/ovnkube-db=true
+  command: kubectl label nodes {{ item }} k8s.ovn.org/ovnkube-db=true
   with_items:
     - "{{ groups['master'] }}"
     - "{{ groups['master_slave'] }}"


### PR DESCRIPTION
Following PR broke the kube-ansible deployment

https://github.com/ovn-org/ovn-kubernetes/pull/1152/commits/b61daf1d6d1eb10613f98ce7c313649e90ba98a4
Node lables for OVN is changed, so it's not deploying
the ovnkube-db-X pods on the master nodes and result
in broken deployment.

Signed-off-by: Anil Vishnoi <vishnoianil@gmail.com>