### PR TITLE
Provide config knobs to specify ovn-kubernets repo and branch

### DIFF
--- a/playbooks/ka-init/group_vars/all.yml
+++ b/playbooks/ka-init/group_vars/all.yml
@@ -100,6 +100,9 @@ kubectl_proxy_port: 8088
 # ----------------------------
 ovn_image_repo: "docker.io/ovnkube/ovn-daemonset-u:latest"
 
+# OVN Kubernets repo and branch
+#ovn_kubernetes_repo: https://github.com/ovn-org/ovn-kubernetes
+#ovn_kubernetes_branch: master
 # Setup ovn-kubernetes in clustered HA mode (Raft based)
 #enable_ovn_raft: True
 

--- a/roles/ovnkube-setup/tasks/main.yml
+++ b/roles/ovnkube-setup/tasks/main.yml
@@ -11,8 +11,9 @@
 
     - name: git clone # noqa 401
       git:
-        repo: https://github.com/ovn-org/ovn-kubernetes
+        repo: "{{ ovn_kubernetes_repo | default('https://github.com/ovn-org/ovn-kubernetes') }}"
         dest: ${HOME}/work/src/github.com/ovn-org/ovn-kubernetes
+        version: "{{ ovn_kubernetes_branch | default('master') }}"
 
     - name: set kube_api_server
       set_fact:


### PR DESCRIPTION
kube-ansible project clones the ovn-kubernetes project
and build the project to generate the OVN deployment yaml
files. Currently it's hardcoded to clone the official
ovn-kubernets repo and build the master branch by default.
Currently there is no way user can test it's work-in-progress
patch for ovn-kubernetes, specifically if that patch changes
the code that is not part of the ovn-kubernetes image, which
user can build from any repo and branch, like updating the
deployment yaml files.

Signed-off-by: Anil Vishnoi <vishnoianil@gmail.com>