### PR TITLE
Expose the log levels for OVN components

### DIFF
--- a/playbooks/ka-init/group_vars/all.yml
+++ b/playbooks/ka-init/group_vars/all.yml
@@ -101,10 +101,32 @@ kubectl_proxy_port: 8088
 ovn_image_repo: "docker.io/ovnkube/ovn-daemonset-u:latest"
 
 # OVN Kubernets repo and branch
-#ovn_kubernetes_repo: https://github.com/ovn-org/ovn-kubernetes
-#ovn_kubernetes_branch: master
+# ovn_kubernetes_repo: https://github.com/ovn-org/ovn-kubernetes
+# ovn_kubernetes_branch: master
 # Setup ovn-kubernetes in clustered HA mode (Raft based)
-#enable_ovn_raft: True
+# enable_ovn_raft: True
+
+# Set logging parameters for different OVN components
+# Log level for ovnkube master
+# ovnkube_master_loglevel: "5"
+
+# Log level for ovnkube node
+# ovnkube_node_loglevel: "5"
+
+# Log config for ovn northd
+# ovn_loglevel_northd: "-vconsole:info -vfile:info"
+
+# Log config for OVN Northbound Database
+# ovn_loglevel_nb: "-vconsole:info -vfile:info"
+
+# Log config for OVN Southbound Database
+# ovn_loglevel_sb: "-vconsole:info -vfile:info"
+
+# Log config for OVN Controller
+# ovn_loglevel_controller: "-vconsole:info"
+
+# Log config for OVN NBCTL daemon
+# ovn_loglevel_nbctld: "-vconsole:info"
 
 # ----------------------------
 # virt-host vars.

--- a/roles/ovnkube-setup/tasks/main.yml
+++ b/roles/ovnkube-setup/tasks/main.yml
@@ -27,8 +27,17 @@
     - name: create ovn yaml file
       shell: |
         ./daemonset.sh --image={{ ovn_image_repo }} \
-                --net-cidr=10.244.0.0/16 --svc-cidr=10.96.0.0/12 \
-                --gateway-mode="local" --k8s-apiserver={{ kube_api_server }}
+                --net-cidr=10.244.0.0/16 \
+                --svc-cidr=10.96.0.0/12 \
+                --gateway-mode="local" \
+                --k8s-apiserver={{ kube_api_server }} \
+                --master-loglevel="{{ ovnkube_master_loglevel | default('5') }}" \
+                --node-loglevel="{{ ovnkube_node_loglevel | default('4') }}" \
+                --ovn-loglevel-northd="{{ ovn_loglevel_northd | default('-vfile:info') }}" \
+                --ovn-loglevel-nb="{{ ovn_loglevel_nb | default('-vfile:info') }}" \
+                --ovn-loglevel-sb="{{ ovn_loglevel_sb | default('-vfile:info') }}" \
+                --ovn-loglevel-controller="{{ ovn_loglevel_controller | default('-vfile:info') }}" \
+                --ovn-loglevel-nbctld="{{ ovn_loglevel_nbctld | default('-vfile:info') }}"
       args:
         chdir: $HOME/work/src/github.com/ovn-org/ovn-kubernetes/dist/images
 


### PR DESCRIPTION
Currently log level for OVN component is by default hardcoded to info level. 
To change the log level, user need to use ovn-appctl to configure log for individual component. 
In a development environment, where setups are created/destroyed frequently, exposing these 
log levels at deployment time is real time saver.

Signed-off-by: Anil Vishnoi <vishnoianil@gmail.com>