### PR TITLE
customize cri-o build install git url

### DIFF
--- a/roles/cri-o-install/defaults/main.yml
+++ b/roles/cri-o-install/defaults/main.yml
@@ -1,0 +1,3 @@
+crio_giturl: https://github.com/cri-o/cri-o.git
+crio_version: master
+

--- a/roles/cri-o-install/tasks/build_install.yml
+++ b/roles/cri-o-install/tasks/build_install.yml
@@ -50,7 +50,7 @@
 
 - name: clone CRI-O
   git:
-    repo: https://github.com/cri-o/cri-o.git
+    repo: "{{ crio_giturl|default('https://github.com/cri-o/cri-o.git') }}"
     dest: "{{ ansible_env.HOME }}/{{ gopath }}/src/github.com/cri-o/cri-o"
     version: "{{ crio_version|default('master') }}"
 


### PR DESCRIPTION
This is to make the cri-o build install able to use a customized git url. If the git url is not specified explicitly in the configuration (such as in playbooks/ka-init/group_vars/all.yml) or extra-vars, then the default will still be used.

This can be used for other component build, but only come across the needs for cri-o customer build so far.