### PR TITLE
Pod_network_cidr should include prefix

### DIFF
--- a/playbooks/ka-init/group_vars/all.yml
+++ b/playbooks/ka-init/group_vars/all.yml
@@ -34,7 +34,7 @@ conmon_binary_url: https://github.com/containers/conmon/releases/download/v2.0.2
 # Network type (2nics or default)
 network_type: "default"
 # Pod net work CIDR
-pod_network_cidr: "10.244.0.0"
+pod_network_cidr: "10.244.0.0/16"
 
 # General config
 

--- a/roles/kube-init/templates/kubeadm.cfg.v1alpha.j2
+++ b/roles/kube-init/templates/kubeadm.cfg.v1alpha.j2
@@ -12,7 +12,7 @@ apiServerExtraArgs:
   feature-gates: DevicePlugins=true
 {% endif %}
 networking:
-  podSubnet: {{ pod_network_cidr }}/16
+  podSubnet: {{ pod_network_cidr }}
 kubeletConfiguration:
   baseConfig:
     cgroupDriver: systemd

--- a/roles/kube-init/templates/kubeadm.cfg.v1beta.j2
+++ b/roles/kube-init/templates/kubeadm.cfg.v1beta.j2
@@ -6,7 +6,7 @@ apiServer:
   extraArgs:
     enable-admission-plugins: NodeRestriction,MutatingAdmissionWebhook,ValidatingAdmissionWebhook
 networking:
-  podSubnet: {{ pod_network_cidr }}/16
+  podSubnet: {{ pod_network_cidr }}
 {% if control_plane_listen_all %}
 controllerManager:
   extraArgs:

--- a/roles/kube-init/templates/kubeadm.cfg.v1beta2.j2
+++ b/roles/kube-init/templates/kubeadm.cfg.v1beta2.j2
@@ -29,7 +29,7 @@ apiServer:
     feature-gates: "EndpointSlice=true"
 {% endif %}
 networking:
-  podSubnet: {{ pod_network_cidr }}/16
+  podSubnet: {{ pod_network_cidr }}
 {% if control_plane_listen_all %}
 controllerManager:
   extraArgs:


### PR DESCRIPTION
Make pod_network_cidr in group_vars/all.yml and podSubnet in kubeadm.cfg support prefixes other than /16.